### PR TITLE
feat: add logic to startup script to set, check, and validate config variables

### DIFF
--- a/pulumi/aws/README.md
+++ b/pulumi/aws/README.md
@@ -42,7 +42,9 @@ Since this project illustrates deploying to AWS,
 is necessary. If you want to avoid using environment variables, AWS profile
 and region definitions can be contained in the `config/Pulumi.<stack>.yaml` 
 files in each project. Refer to the Pulumi documentation for details on how to
-do this.
+do this. The script [`startup_all.sh`](./startup_all.sh) will prompt you to add 
+the AWS region and profile values that will then be added to the `config/Pulumi.<stack>.yaml`
+in each project directory.
 
 If the [`aws` CLI](https://aws.amazon.com/cli/) is installed, it will be used
 in the setup bash scripts to update your `kubectl` local configuration to use
@@ -70,7 +72,11 @@ The easiest way to run the project is to run [`start_all.sh`](./start_all.sh)
 after you have  completed the steps in [requirements](README.md#requirements).
 When doing so, be sure to choose the same 
 [Pulumi stack name](https://www.pulumi.com/docs/intro/concepts/stack/) 
-for all of your projects. Alternatively, you can enter into each Pulumi
+for all of your projects. Additionally, this script will prompt you for the
+AWS region and profile information. This information will be used to populate
+the `config/Pulumi.<stack>.yaml` files in each project directory.
+
+Alternatively, you can enter into each Pulumi
 project directory and execute each project independently by doing 
 `pulumi up`. Take a look at `start_all.sh` to get a feel for the flow.
 

--- a/pulumi/aws/logagent/__main__.py
+++ b/pulumi/aws/logagent/__main__.py
@@ -56,7 +56,7 @@ chart_ops = helm.ChartOpts(
         namespace=ns.metadata.name,
         repo=FILEBEAT_HELM_REPO_NAME,
         fetch_opts=FetchOpts(repo=FILEBEAT_HELM_REPO_URL),
-        version='7.13.2',
+        version='7.13.1',
         values=chart_values,
         transformations=[remove_status_field]
     )

--- a/pulumi/aws/start_all.sh
+++ b/pulumi/aws/start_all.sh
@@ -48,7 +48,10 @@ find "${script_dir}" -mindepth 2 -maxdepth 2 -type f -name Pulumi.yaml -execdir 
 if [[ -z "${AWS_PROFILE+x}" ]] ; then
   echo "AWS_PROFILE not set"
   if ! grep --quiet '^AWS_PROFILE=.*' "${script_dir}/config/environment"; then
-    read -r -e -p "Enter the name of the AWS Profile to use in all projects: " AWS_PROFILE
+    read -r -e -p "Enter the name of the AWS Profile to use in all projects (leave blank for default): " AWS_PROFILE
+      if [[ -z "${AWS_PROFILE}" ]] ; then
+        AWS_PROFILE=default
+      fi
     echo "AWS_PROFILE=${AWS_PROFILE}" >> "${script_dir}/config/environment"
     source "${script_dir}/config/environment"
     find "${script_dir}" -mindepth 2 -maxdepth 2 -type f -name Pulumi.yaml -execdir pulumi config set aws:profile "${AWS_PROFILE}" \;


### PR DESCRIPTION
### Proposed changes
This update adds some additional logic to the start_all.sh script that is intended to make it 
easier for first-time users. 
1. When selecting a stack, the script will create the stack with the name given if one does not already exist.
2. The script will prompt for and add the AWS profile to the Pulumi configuration files in each project directory.
3. The script will prompt for and add the AWS region to the Puumi configuration files in each project directory.

The readme file has been updated to include this information.

There is one minor fix in this PR; elastic has pulled filebeat 7.13.2 from their repo, so we have reverted to 7.13.1. 

### Checklist

- [X] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [X] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [X] I have added tests (when possible) that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [X] I have updated necessary documentation
- [X] I have rebased my branch onto master
- [X] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
