### PR TITLE
feat: add git url support to kic-image-build

### DIFF
--- a/pulumi/aws/README.md
+++ b/pulumi/aws/README.md
@@ -35,6 +35,11 @@ In order to run this project, you will need to first [download, install and
 configure Pulumi](https://www.pulumi.com/docs/get-started/install/) for 
 your environment.
 
+### Git
+
+The `git` command line tool is required for checking out KIC source code from
+github and for the KIC image build process.
+
 ### AWS
 
 Since this project illustrates deploying to AWS, 

--- a/pulumi/aws/config/Pulumi.stackname.yaml.example
+++ b/pulumi/aws/config/Pulumi.stackname.yaml.example
@@ -33,8 +33,33 @@ config:
   # By default the latest version of the NGINX Kubernetes Ingress Controller
   # source code will be downloaded and built unless an alternative URL is
   # provided for the kic_src_url parameter. To use the default, just omit this key.
-  # Additionally, this configuration value can also point to a directory on the local file system.
-  kic:src_url: https://github.com/nginxinc/kubernetes-ingress/archive/refs/tags/v1.11.3.tar.gz
+  # URLs can point to a directory path on the local filesystem, tar.gz archive, or to a
+  # git repository. Specify a tag/commit/branch for a git repository URL in the fragment.
+  #
+  # Example URLs:
+  #
+  # HTTP/HTTPS url pointing to a tar.gz archive:
+  # https://github.com/nginxinc/kubernetes-ingress/archive/refs/tags/v1.11.3.tar.gz
+  #
+  # tar.gz archive on the local filesystem:
+  # file:///var/tmp/v1.11.3.tar.gz
+  # /var/tmp/v1.11.3.tar.gz
+  #
+  # Directory containing the source tree on the local filesystem:
+  # file:///var/tmp/kubernetes-ingress-1.11.3
+  # /var/tmp/kubernetes-ingress-1.11.3
+  #
+  # Github URL without a tag specified:
+  # https://github.com/nginxinc/kubernetes-ingress.git
+  # git@github.com:nginxinc/kubernetes-ingress.git
+  # ssh://git@github.com:nginxinc/kubernetes-ingress.git
+  #
+  # Github URL with a tag specified:
+  # https://github.com/nginxinc/kubernetes-ingress.git#v1.12.0
+  # git@github.com:nginxinc/kubernetes-ingress.git#v1.12.0
+  # ssh://git@github.com:nginxinc/kubernetes-ingress.git#v1.12.0
+
+  kic:src_url: https://github.com/nginxinc/kubernetes-ingress.git#v1.12.0
   # When set to true, Pulumi's diff logic is circumvented and the image will always be
   # rebuilt regardless of the input variables to Pulumi being the same or not.
   kic:always_rebuild: false

--- a/pulumi/aws/kic-image-build/ingress_controller_image.py
+++ b/pulumi/aws/kic-image-build/ingress_controller_image.py
@@ -83,23 +83,17 @@ class IngressControllerImageArgs:
 
 
 class IngressControllerSourceArchiveUrl:
-    LAST_KNOWN_KIC_VERSION = '1.12.0'
     DOWNLOAD_URL = 'https://github.com/nginxinc/kubernetes-ingress.git'
 
     @staticmethod
     def latest_version() -> str:
-        version = IngressControllerSourceArchiveUrl.LAST_KNOWN_KIC_VERSION
-
-        try:
-            ping_url = 'https://github.com/nginxinc/kubernetes-ingress/releases/latest'
-            response = requests.head(ping_url)
-            redirect = response.headers.get('location')
-            tag_url = parse.urlparse(redirect)
-            tag_url_path = tag_url.path
-            elements = tag_url_path.split('/')
-            version = elements[-1]
-        except:
-            pass
+        ping_url = 'https://github.com/nginxinc/kubernetes-ingress/releases/latest'
+        response = requests.head(ping_url)
+        redirect = response.headers.get('location')
+        tag_url = parse.urlparse(redirect)
+        tag_url_path = tag_url.path
+        elements = tag_url_path.split('/')
+        version = str(elements[-1])
 
         return version
 

--- a/pulumi/aws/kic-image-build/ingress_controller_image.py
+++ b/pulumi/aws/kic-image-build/ingress_controller_image.py
@@ -1,17 +1,11 @@
 import argparse
-import atexit
-import gzip
 import os.path
 import re
 import shlex
-import shutil
-import tarfile
-import tempfile
 import uuid
 import pathlib
 from typing import Optional, Any, List, Dict
-from urllib import request, parse
-from enum import Enum
+from urllib import parse
 
 import pulumi
 import requests
@@ -19,7 +13,8 @@ from pulumi.dynamic import ResourceProvider, Resource, CreateResult, CheckResult
     UpdateResult, DiffResult
 
 from kic_util.docker_image_name import DockerImageName
-from kic_util import external_process
+from kic_util import external_process, archive_download
+from kic_util.url_type import URLType
 
 __all__ = [
     'IngressControllerImage',
@@ -29,9 +24,8 @@ __all__ = [
 ]
 
 
-class DownloadExtractError(RuntimeError):
-    """Error class thrown when there is a problem getting KIC source"""
-    pass
+class ImageBuildStateError(RuntimeError):
+    """Error class thrown when there is a runtime problem building the KIC image"""
 
 
 class ImageBuildOutputParseError(RuntimeError):
@@ -86,13 +80,6 @@ class IngressControllerImageArgs:
     @pulumi.getter
     def make_target(self) -> Optional[pulumi.Input[str]]:
         return pulumi.get(self, "make_target")
-
-
-class URLType(Enum):
-    GENERAL_TAR_GZ = 0
-    LOCAL_TAR_GZ = 1
-    LOCAL_PATH = 2
-    UNKNOWN = 3
 
 
 class IngressControllerSourceArchiveUrl:
@@ -220,59 +207,17 @@ class IngressControllerImageProvider(ResourceProvider):
         return None
 
     @staticmethod
-    def identify_url_type(url: str) -> (URLType, parse.ParseResult):
-        result = parse.urlparse(url, allow_fragments=False)
-        is_tarball = result.path.endswith('.tar.gz')
-        url_type = URLType.UNKNOWN
-
-        if result.scheme == 'file':
-            url_type = URLType.LOCAL_TAR_GZ if is_tarball else URLType.LOCAL_PATH
-        elif result.scheme == '':
-            path = pathlib.Path(url)
-            if path.is_dir():
-                url_type = URLType.LOCAL_PATH
-            elif path.is_file() and is_tarball:
-                url_type = URLType.LOCAL_TAR_GZ
-        elif is_tarball:
-            url_type = URLType.GENERAL_TAR_GZ
-
-        return url_type, result
-
-    @staticmethod
     def find_kic_source_dir(url: str) -> str:
-        url_type, result = IngressControllerImageProvider.identify_url_type(url)
+        extracted_path = archive_download.download_and_extract_archive_from_url(url)
 
-        if url_type == URLType.GENERAL_TAR_GZ or url_type == URLType.LOCAL_TAR_GZ:
-            extracted_path = IngressControllerImageProvider.download_and_extract_kic_source(result.geturl())
-            listing = os.listdir(extracted_path)
-            if len(listing) != 1:
-                raise DownloadExtractError(f'Multiple top level items found in path: {extracted_path}')
+        # Sometimes the extracted directory contains a single directory that represents the
+        # name and version of the KIC release. In that case, we navigate to that directory
+        # and use it as our source directory.
+        listing = os.listdir(extracted_path)
+        if len(listing) == 1:
             return os.path.join(extracted_path, listing[0])
-        elif url_type == URLType.LOCAL_PATH:
-            return result.path
         else:
-            raise ValueError(f'Unknown URLType: {url_type}')
-
-    @staticmethod
-    def download_and_extract_kic_source(url: str):
-        temp_dir = tempfile.mkdtemp(prefix='kic-src_')
-        # Limit access of directory to only the creating user
-        os.chmod(path=temp_dir, mode=0o0700)
-        # Delete source directory upon exit, so that we don't have cruft lying around
-        atexit.register(lambda: shutil.rmtree(temp_dir))
-
-        # Download archive
-        try:
-            # Read the file inside the .gz archive located at url
-            with request.urlopen(url) as response:
-                with gzip.GzipFile(fileobj=response) as uncompressed:
-                    with tarfile.TarFile(fileobj=uncompressed) as tarball:
-                        tarball.extractall(path=temp_dir)
-
-        except Exception as e:
-            msg = f'Unable to download and/or extract KIC source from [{url}] to directory [{temp_dir}]'
-            raise DownloadExtractError(f"{msg}\n  cause: {e}") from e
-        return temp_dir
+            return extracted_path
 
     def link_nginx_plus_files_to_source_dir(self, nginx_plus_args: NginxPlusArgs, source_dir: str):
         key_path = pathlib.Path(nginx_plus_args['key_path'])
@@ -313,9 +258,10 @@ class IngressControllerImageProvider(ResourceProvider):
         make_target = props['make_target']
 
         source_dir = IngressControllerImageProvider.find_kic_source_dir(kic_src_url)
+        pulumi.log.debug(f'Building KIC in source directory: {source_dir}', self.resource)
 
         if not os.path.isdir(source_dir):
-            raise DownloadExtractError(f'Expected source code directory not found at path: {source_dir}')
+            raise ImageBuildStateError(f'Expected source code directory not found at path: {source_dir}')
 
         # Link nginx repo certificates into the source directory so that they can be referenced from the build process
         if 'nginx_plus_args' in props and props['nginx_plus_args']:
@@ -364,12 +310,8 @@ class IngressControllerImageProvider(ResourceProvider):
         for p in self.REQUIRED_PROPS:
             check_for_param(p)
 
-        url_type, parse_result = IngressControllerImageProvider.identify_url_type(news['kic_src_url'])
-
-        # Parse the URL as a local path if there is no scheme assigned
-        if not parse_result.scheme:
-            news['kic_src_url'] = f"file://{news['kic_src_url']}"
-            url_type, parse_result = IngressControllerImageProvider.identify_url_type(news['kic_src_url'])
+        parse_result = parse.urlparse(news['kic_src_url'], allow_fragments=False)
+        url_type = URLType.from_parsed_url(parse_result)
 
         if url_type == URLType.UNKNOWN:
             failures.append(CheckFailure(property_='kic_src_url', reason=f"unsupported URL: {news['kic_src_url']}"))

--- a/pulumi/aws/kic-image-build/ingress_controller_image.py
+++ b/pulumi/aws/kic-image-build/ingress_controller_image.py
@@ -83,8 +83,8 @@ class IngressControllerImageArgs:
 
 
 class IngressControllerSourceArchiveUrl:
-    LAST_KNOWN_KIC_VERSION = '1.11.3'
-    DOWNLOAD_URL = f'https://github.com/nginxinc/kubernetes-ingress/archive/refs/tags/|%|VERSION|%|.tar.gz'
+    LAST_KNOWN_KIC_VERSION = '1.12.0'
+    DOWNLOAD_URL = 'https://github.com/nginxinc/kubernetes-ingress.git'
 
     @staticmethod
     def latest_version() -> str:
@@ -108,7 +108,7 @@ class IngressControllerSourceArchiveUrl:
         if not version:
             version = IngressControllerSourceArchiveUrl.latest_version()
 
-        return IngressControllerSourceArchiveUrl.DOWNLOAD_URL.replace('|%|VERSION|%|', version)
+        return f'{IngressControllerSourceArchiveUrl.DOWNLOAD_URL}#{version}'
 
 
 class IngressControllerImageProvider(ResourceProvider):
@@ -310,7 +310,7 @@ class IngressControllerImageProvider(ResourceProvider):
         for p in self.REQUIRED_PROPS:
             check_for_param(p)
 
-        parse_result = parse.urlparse(news['kic_src_url'], allow_fragments=False)
+        parse_result = parse.urlparse(news['kic_src_url'])
         url_type = URLType.from_parsed_url(parse_result)
 
         if url_type == URLType.UNKNOWN:

--- a/pulumi/aws/kic-image-build/test_build_kic_image.py
+++ b/pulumi/aws/kic-image-build/test_build_kic_image.py
@@ -1,8 +1,5 @@
-import atexit
-import shutil
 import os
 import unittest
-import tempfile
 import ingress_controller_image as kic_image
 
 
@@ -185,47 +182,3 @@ class TestKICImage(unittest.TestCase):
         expected = 'sha256:9358beb5cb1c6d6a9c005b18bdad08b0f2259b82d32687b03334256cbd500997'
         actual = self.kic_image_provider.parse_image_id_from_output(stderr)
         self.assertEqual(expected, actual)
-
-    def test_identify_url_type_remote_http(self):
-        url = 'http://github.com/nginxinc/kubernetes-ingress/archive/refs/tags/v1.11.1.tar.gz'
-        expected = kic_image.URLType.GENERAL_TAR_GZ
-        actual, _ = self.kic_image_provider.identify_url_type(url)
-        self.assertEqual(expected, actual)
-
-    def test_identify_url_type_remote_https(self):
-        url = 'https://github.com/nginxinc/kubernetes-ingress/archive/refs/tags/v1.11.1.tar.gz'
-        expected = kic_image.URLType.GENERAL_TAR_GZ
-        actual, _ = self.kic_image_provider.identify_url_type(url)
-        self.assertEqual(expected, actual)
-
-    def test_identify_url_type_remote_ftp(self):
-        url = 'ftp://github.com/nginxinc/kubernetes-ingress/archive/refs/tags/v1.11.1.tar.gz'
-        expected = kic_image.URLType.GENERAL_TAR_GZ
-        actual, _ = self.kic_image_provider.identify_url_type(url)
-        self.assertEqual(expected, actual)
-
-    def test_identify_url_type_local_file_with_scheme(self):
-        url = 'file:///tmp/v1.11.1.tar.gz'
-        expected = kic_image.URLType.LOCAL_TAR_GZ
-        actual, _ = self.kic_image_provider.identify_url_type(url)
-        self.assertEqual(expected, actual)
-
-    def test_identify_url_type_local_file_without_scheme(self):
-        _, local_path = tempfile.mkstemp(prefix='unit_test_file', suffix='.tar.gz', text=True)
-        atexit.register(lambda: os.unlink(local_path))
-        expected = kic_image.URLType.LOCAL_TAR_GZ
-        actual, _ = self.kic_image_provider.identify_url_type(local_path)
-        self.assertEqual(expected, actual, f'path [{local_path}] was misidentified')
-
-    def test_identify_url_type_local_dir_with_scheme(self):
-        url = 'file:///usr/local/src/kic'
-        expected = kic_image.URLType.LOCAL_PATH
-        actual, _ = self.kic_image_provider.identify_url_type(url)
-        self.assertEqual(expected, actual, f'url [{url}] was misidentified')
-
-    def test_identify_url_type_local_dir_without_scheme(self):
-        local_path = tempfile.mkdtemp(prefix='unit_test_dir')
-        atexit.register(lambda: shutil.rmtree(local_path))
-        expected = kic_image.URLType.LOCAL_PATH
-        actual, _ = self.kic_image_provider.identify_url_type(local_path)
-        self.assertEqual(expected, actual, f'path [{local_path}] was misidentified')

--- a/pulumi/aws/kic-pulumi-utils/kic_util/archive_download.py
+++ b/pulumi/aws/kic-pulumi-utils/kic_util/archive_download.py
@@ -1,0 +1,74 @@
+import atexit
+import gzip
+import os
+import shutil
+import tarfile
+import tempfile
+from typing import Optional
+from urllib import request, parse
+from kic_util.url_type import URLType
+
+
+class DownloadExtractError(RuntimeError):
+    """Error class thrown when there is a problem downloading and extracting an archive"""
+    url: Optional[str]
+    temp_dir: Optional[str]
+
+    def __init__(self, url: Optional[str], temp_dir: Optional[str]) -> None:
+        self.url = url
+        self.temp_dir = temp_dir
+
+    def msg(self) -> str:
+        msg = f'Unable to download and/or extract archive from [{self.url}] to directory [{self.temp_dir}]\n' \
+              f'Cause: {self.__cause__}'
+        return msg
+
+    def __str__(self) -> str:
+        return self.msg()
+
+
+def download_and_extract_archive_from_url(url: str) -> str:
+    parsed_url = parse.urlparse(url, allow_fragments=False)
+    archive_url_type = URLType.from_parsed_url(parsed_url)
+
+    if archive_url_type == URLType.GENERAL_TAR_GZ:
+        return download_and_extract_targz_archive_from_url(url=url, temp_prefix='archive_download')
+    elif archive_url_type == URLType.LOCAL_TAR_GZ:
+        return download_and_extract_targz_archive_from_url(url=url, temp_prefix='archive_local')
+    elif archive_url_type == URLType.LOCAL_PATH:
+        return parsed_url.path
+
+    raise ValueError(f'Unable to download archive for unsupported url: {url}')
+
+
+def download_and_extract_targz_archive_from_url(url: str, temp_prefix: Optional[str]) -> str:
+    def download(extract_dir: tempfile):
+        with request.urlopen(url) as response:
+            with gzip.GzipFile(fileobj=response) as uncompressed:
+                with tarfile.TarFile(fileobj=uncompressed) as tarball:
+                    tarball.extractall(path=extract_dir)
+
+    try:
+        temp_dir = extract_stream_into_temp_dir(extract_func=download, temp_prefix=temp_prefix)
+        return str(temp_dir)
+    except DownloadExtractError as e:
+        e.url = url
+        raise e
+    except Exception as e:
+        raise DownloadExtractError(url=url, temp_dir=None) from e
+
+
+def extract_stream_into_temp_dir(extract_func, temp_prefix: Optional[str]) -> str:
+    temp_dir = tempfile.mkdtemp(prefix=temp_prefix)
+    # Limit access of directory to only the creating user
+    os.chmod(path=temp_dir, mode=0o0700)
+    # Delete extracted directory upon exit, so that we don't have cruft lying around
+    atexit.register(lambda: shutil.rmtree(temp_dir))
+
+    # Download archive
+    try:
+        extract_func(temp_dir)
+    except Exception as e:
+        raise DownloadExtractError(url=None, temp_dir=temp_dir) from e
+
+    return str(temp_dir)

--- a/pulumi/aws/kic-pulumi-utils/kic_util/archive_download.py
+++ b/pulumi/aws/kic-pulumi-utils/kic_util/archive_download.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import tarfile
 import tempfile
+from git import Repo
 from typing import Optional
 from urllib import request, parse
 from kic_util.url_type import URLType
@@ -28,15 +29,17 @@ class DownloadExtractError(RuntimeError):
 
 
 def download_and_extract_archive_from_url(url: str) -> str:
-    parsed_url = parse.urlparse(url, allow_fragments=False)
+    parsed_url = parse.urlparse(url)
     archive_url_type = URLType.from_parsed_url(parsed_url)
 
     if archive_url_type == URLType.GENERAL_TAR_GZ:
-        return download_and_extract_targz_archive_from_url(url=url, temp_prefix='archive_download')
+        return download_and_extract_targz_archive_from_url(url=url, temp_prefix='archive_download_')
     elif archive_url_type == URLType.LOCAL_TAR_GZ:
-        return download_and_extract_targz_archive_from_url(url=url, temp_prefix='archive_local')
+        return download_and_extract_targz_archive_from_url(url=url, temp_prefix='archive_local_')
     elif archive_url_type == URLType.LOCAL_PATH:
         return parsed_url.path
+    elif archive_url_type == URLType.GIT_REPO:
+        return checkout_from_git(parsed_url=parsed_url, temp_prefix='archive_git_')
 
     raise ValueError(f'Unable to download archive for unsupported url: {url}')
 
@@ -56,6 +59,57 @@ def download_and_extract_targz_archive_from_url(url: str, temp_prefix: Optional[
         raise e
     except Exception as e:
         raise DownloadExtractError(url=url, temp_dir=None) from e
+
+
+def checkout_from_git(parsed_url: parse.ParseResult, temp_prefix: Optional[str]) -> str:
+    # Rebuild the parsed URL without the fragment so that git understands it.
+    url = clone_and_clean_parsed_url(parsed_url).geturl()
+    tag = parsed_url.fragment
+
+    def checkout(working_dir: tempfile):
+        opts = ['--depth', '1']
+
+        if tag:
+            opts.append('--branch')
+            opts.append(tag)
+
+        Repo.clone_from(url=url, to_path=working_dir, multi_options=opts)
+
+    try:
+        temp_dir = extract_stream_into_temp_dir(extract_func=checkout, temp_prefix=temp_prefix)
+        return str(temp_dir)
+    except DownloadExtractError as e:
+        e.url = url
+        raise e
+    except Exception as e:
+        raise DownloadExtractError(url=url, temp_dir=None) from e
+
+
+def clone_and_clean_parsed_url(parsed_url: parse.ParseResult) -> parse.ParseResult:
+    """Clones the passed ParseResult object without a fragment and removes
+    ssh scheme so that the resulting ParseResult object can covert to a git compatible URL.
+
+    :rtype: parse.ParseResult
+    :param parsed_url: URL object to clone
+    :return: A new URL object without a fragment and/or without a scheme if the input scheme is 'ssh'
+    """
+
+    if parsed_url.scheme == 'ssh':
+        # noinspection PyArgumentList
+        return parse.ParseResult(scheme='',
+                                 netloc='',
+                                 path=parsed_url.netloc + parsed_url.path,
+                                 query=parsed_url.query,
+                                 fragment='',
+                                 params='')
+
+    # noinspection PyArgumentList
+    return parse.ParseResult(scheme=parsed_url.scheme,
+                             netloc=parsed_url.netloc,
+                             path=parsed_url.path,
+                             query=parsed_url.query,
+                             fragment='',
+                             params='')
 
 
 def extract_stream_into_temp_dir(extract_func, temp_prefix: Optional[str]) -> str:

--- a/pulumi/aws/kic-pulumi-utils/kic_util/test_archive_download.py
+++ b/pulumi/aws/kic-pulumi-utils/kic_util/test_archive_download.py
@@ -1,0 +1,69 @@
+import unittest
+
+from urllib import parse
+from kic_util.archive_download import clone_and_clean_parsed_url
+
+
+class TestArchiveDownload(unittest.TestCase):
+    without_schema = None
+    with_schema = None
+
+    def test_clone_and_clean_parsed_url_https_scheme(self):
+        url = 'https://github.com/nginxinc/kubernetes-ingress.git'
+        parsed_result = parse.urlparse(url=url)
+        cleaned_result = clone_and_clean_parsed_url(parsed_url=parsed_result)
+        self.with_schema = cleaned_result
+        actual = cleaned_result.geturl()
+        expected = 'https://github.com/nginxinc/kubernetes-ingress.git'
+
+        self.assertEqual(expected, actual)
+
+    def test_clone_and_clean_parsed_url_https_scheme_and_fragment(self):
+        url = 'https://github.com/nginxinc/kubernetes-ingress.git#v1.11.2'
+        parsed_result = parse.urlparse(url=url)
+        cleaned_result = clone_and_clean_parsed_url(parsed_url=parsed_result)
+        self.with_schema = cleaned_result
+        actual = cleaned_result.geturl()
+        expected = 'https://github.com/nginxinc/kubernetes-ingress.git'
+
+        self.assertEqual(expected, actual)
+
+    def test_clone_and_clean_parsed_url_ssh_scheme(self):
+        url = 'ssh://git@github.com:nginxinc/kubernetes-ingress.git'
+        parsed_result = parse.urlparse(url=url)
+        cleaned_result = clone_and_clean_parsed_url(parsed_url=parsed_result)
+        self.with_schema = cleaned_result
+        actual = cleaned_result.geturl()
+        expected = 'git@github.com:nginxinc/kubernetes-ingress.git'
+
+        self.assertEqual(expected, actual)
+
+    def test_clone_and_clean_parsed_url_ssh_scheme_and_fragment(self):
+        url = 'ssh://git@github.com:nginxinc/kubernetes-ingress.git#v1.11.2'
+        parsed_result = parse.urlparse(url=url)
+        cleaned_result = clone_and_clean_parsed_url(parsed_url=parsed_result)
+        self.with_schema = cleaned_result
+        actual = cleaned_result.geturl()
+        expected = 'git@github.com:nginxinc/kubernetes-ingress.git'
+
+        self.assertEqual(expected, actual)
+
+    def test_clone_and_clean_parsed_url_without_scheme(self):
+        url = 'git@github.com:nginxinc/kubernetes-ingress.git'
+        parsed_result = parse.urlparse(url=url)
+        cleaned_result = clone_and_clean_parsed_url(parsed_url=parsed_result)
+        self.without_schema = cleaned_result
+        actual = cleaned_result.geturl()
+        expected = 'git@github.com:nginxinc/kubernetes-ingress.git'
+
+        self.assertEqual(expected, actual)
+
+    def test_clone_and_clean_parsed_url_without_scheme_and_fragment(self):
+        url = 'git@github.com:nginxinc/kubernetes-ingress.git#v1.11.2'
+        parsed_result = parse.urlparse(url=url)
+        cleaned_result = clone_and_clean_parsed_url(parsed_url=parsed_result)
+        self.without_schema = cleaned_result
+        actual = cleaned_result.geturl()
+        expected = 'git@github.com:nginxinc/kubernetes-ingress.git'
+
+        self.assertEqual(expected, actual)

--- a/pulumi/aws/kic-pulumi-utils/kic_util/test_url_type.py
+++ b/pulumi/aws/kic-pulumi-utils/kic_util/test_url_type.py
@@ -1,0 +1,53 @@
+import atexit
+import os
+import shutil
+import tempfile
+import unittest
+
+from kic_util.url_type import URLType
+
+
+class TestURLType(unittest.TestCase):
+    def test_identify_url_type_remote_http(self):
+        url = 'http://github.com/nginxinc/kubernetes-ingress/archive/refs/tags/v1.11.1.tar.gz'
+        expected = URLType.GENERAL_TAR_GZ
+        actual = URLType.from_url(url)
+        self.assertEqual(expected, actual)
+
+    def test_identify_url_type_remote_https(self):
+        url = 'https://github.com/nginxinc/kubernetes-ingress/archive/refs/tags/v1.11.1.tar.gz'
+        expected = URLType.GENERAL_TAR_GZ
+        actual = URLType.from_url(url)
+        self.assertEqual(expected, actual)
+
+    def test_identify_url_type_remote_ftp(self):
+        url = 'ftp://github.com/nginxinc/kubernetes-ingress/archive/refs/tags/v1.11.1.tar.gz'
+        expected = URLType.GENERAL_TAR_GZ
+        actual = URLType.from_url(url)
+        self.assertEqual(expected, actual)
+
+    def test_identify_url_type_local_file_with_scheme(self):
+        url = 'file:///tmp/v1.11.1.tar.gz'
+        expected = URLType.LOCAL_TAR_GZ
+        actual = URLType.from_url(url)
+        self.assertEqual(expected, actual)
+
+    def test_identify_url_type_local_file_without_scheme(self):
+        _, local_path = tempfile.mkstemp(prefix='unit_test_file', suffix='.tar.gz', text=True)
+        atexit.register(lambda: os.unlink(local_path))
+        expected = URLType.LOCAL_TAR_GZ
+        actual = URLType.from_url(local_path)
+        self.assertEqual(expected, actual, f'path [{local_path}] was misidentified')
+
+    def test_identify_url_type_local_dir_with_scheme(self):
+        url = 'file:///usr/local/src/kic'
+        expected = URLType.LOCAL_PATH
+        actual = URLType.from_url(url)
+        self.assertEqual(expected, actual, f'url [{url}] was misidentified')
+
+    def test_identify_url_type_local_dir_without_scheme(self):
+        local_path = tempfile.mkdtemp(prefix='unit_test_dir')
+        atexit.register(lambda: shutil.rmtree(local_path))
+        expected = URLType.LOCAL_PATH
+        actual = URLType.from_url(local_path)
+        self.assertEqual(expected, actual, f'path [{local_path}] was misidentified')

--- a/pulumi/aws/kic-pulumi-utils/kic_util/test_url_type.py
+++ b/pulumi/aws/kic-pulumi-utils/kic_util/test_url_type.py
@@ -51,3 +51,39 @@ class TestURLType(unittest.TestCase):
         expected = URLType.LOCAL_PATH
         actual = URLType.from_url(local_path)
         self.assertEqual(expected, actual, f'path [{local_path}] was misidentified')
+
+    def test_identify_url_type_github_https_without_tag(self):
+        url = 'https://github.com/nginxinc/kubernetes-ingress.git'
+        expected = URLType.GIT_REPO
+        actual = URLType.from_url(url)
+        self.assertEqual(expected, actual)
+
+    def test_identify_url_type_github_https_with_tag(self):
+        url = 'https://github.com/nginxinc/kubernetes-ingress.git#v1.12.0'
+        expected = URLType.GIT_REPO
+        actual = URLType.from_url(url)
+        self.assertEqual(expected, actual)
+
+    def test_identify_url_type_github_no_schema_without_tag(self):
+        url = 'git@github.com:nginxinc/kubernetes-ingress.git'
+        expected = URLType.GIT_REPO
+        actual = URLType.from_url(url)
+        self.assertEqual(expected, actual)
+
+    def test_identify_url_type_github_no_schema_with_tag(self):
+        url = 'git@github.com:nginxinc/kubernetes-ingress.git#v1.11.3'
+        expected = URLType.GIT_REPO
+        actual = URLType.from_url(url)
+        self.assertEqual(expected, actual)
+
+    def test_identify_url_type_github_ssh_without_tag(self):
+        url = 'ssh://git@github.com:nginxinc/kubernetes-ingress.git'
+        expected = URLType.GIT_REPO
+        actual = URLType.from_url(url)
+        self.assertEqual(expected, actual)
+
+    def test_identify_url_type_github_ssh_with_tag(self):
+        url = 'ssh://git@github.com:nginxinc/kubernetes-ingress.git#v1.12.0'
+        expected = URLType.GIT_REPO
+        actual = URLType.from_url(url)
+        self.assertEqual(expected, actual)

--- a/pulumi/aws/kic-pulumi-utils/kic_util/url_type.py
+++ b/pulumi/aws/kic-pulumi-utils/kic_util/url_type.py
@@ -1,0 +1,40 @@
+import pathlib
+from enum import Enum
+from urllib import parse
+
+
+class URLType(Enum):
+    GENERAL_TAR_GZ = 0
+    LOCAL_TAR_GZ = 1
+    LOCAL_PATH = 2
+    UNKNOWN = 3
+
+    @staticmethod
+    def from_url(url: str) -> Enum:
+        """
+        :rtype: URLType
+        """
+        result = parse.urlparse(url, allow_fragments=False)
+        return URLType.from_parsed_url(result)
+
+    @staticmethod
+    def from_parsed_url(result: parse.ParseResult) -> Enum:
+        """
+        :rtype: URLType
+        """
+        is_tarball = result.path.endswith('.tar.gz')
+        url_type = URLType.UNKNOWN
+
+        if result.scheme == 'file':
+            url_type = URLType.LOCAL_TAR_GZ if is_tarball else URLType.LOCAL_PATH
+        elif result.scheme == '':
+            path = pathlib.Path(result.path)
+            if path.is_dir():
+                url_type = URLType.LOCAL_PATH
+            elif path.is_file() and is_tarball:
+                url_type = URLType.LOCAL_TAR_GZ
+        elif is_tarball:
+            url_type = URLType.GENERAL_TAR_GZ
+
+        return url_type
+

--- a/pulumi/aws/kic-pulumi-utils/kic_util/url_type.py
+++ b/pulumi/aws/kic-pulumi-utils/kic_util/url_type.py
@@ -4,17 +4,18 @@ from urllib import parse
 
 
 class URLType(Enum):
-    GENERAL_TAR_GZ = 0
-    LOCAL_TAR_GZ = 1
-    LOCAL_PATH = 2
-    UNKNOWN = 3
+    GENERAL_TAR_GZ = 1
+    LOCAL_TAR_GZ = 2
+    LOCAL_PATH = 4
+    GIT_REPO = 8
+    UNKNOWN = 16
 
     @staticmethod
     def from_url(url: str) -> Enum:
         """
         :rtype: URLType
         """
-        result = parse.urlparse(url, allow_fragments=False)
+        result = parse.urlparse(url)
         return URLType.from_parsed_url(result)
 
     @staticmethod
@@ -23,18 +24,22 @@ class URLType(Enum):
         :rtype: URLType
         """
         is_tarball = result.path.endswith('.tar.gz')
-        url_type = URLType.UNKNOWN
 
         if result.scheme == 'file':
-            url_type = URLType.LOCAL_TAR_GZ if is_tarball else URLType.LOCAL_PATH
-        elif result.scheme == '':
+            return URLType.LOCAL_TAR_GZ if is_tarball else URLType.LOCAL_PATH
+
+        if result.path.endswith('.git'):
+            return URLType.GIT_REPO
+
+        if result.scheme == '':
             path = pathlib.Path(result.path)
             if path.is_dir():
-                url_type = URLType.LOCAL_PATH
+                return URLType.LOCAL_PATH
             elif path.is_file() and is_tarball:
-                url_type = URLType.LOCAL_TAR_GZ
-        elif is_tarball:
-            url_type = URLType.GENERAL_TAR_GZ
+                return URLType.LOCAL_TAR_GZ
 
-        return url_type
+        if is_tarball:
+            return URLType.GENERAL_TAR_GZ
+
+        return URLType.UNKNOWN
 

--- a/pulumi/aws/kic-pulumi-utils/setup.py
+++ b/pulumi/aws/kic-pulumi-utils/setup.py
@@ -7,5 +7,5 @@ setup(name='kic-pulumi-utils',
       version_config=True,
       packages=['kic_util'],
       install_requires=[
-            'pyyaml>=5.3.1,<6.0', 'passlib>=1.7.4,<2.0.0'
+            'pyyaml>=5.3.1,<6.0', 'passlib>=1.7.4,<2.0.0', 'GitPython>=3.1.18,<3.2.0'
       ])


### PR DESCRIPTION
### Proposed changes
This change adds support to the kic:src_url configuration parameter for git URLs. Additionally, it changes the behavior of the default operation when src_url is left unspecified to check out the KIC source directly from github using the latest tag instead of downloading a tar.gz archive from github.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [X] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [X] I have added tests (when possible) that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [X] I have updated necessary documentation
- [X] I have rebased my branch onto master
- [X] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
