### PR TITLE
feat: add tls support with selfsigned certs

### DIFF
--- a/pulumi/aws/README.md
+++ b/pulumi/aws/README.md
@@ -83,7 +83,8 @@ vpc - defines and installs the VPC and subnets to use with EKS
         └─kic-helm-chart - deploys NGINX Ingress Controller to the EKS cluster 
           └─logstore - deploys a logstore (elasticsearch) to the EKS cluster 
             └─logagent - deploys a logging agent (filebeat) to the EKS cluster 
-              └─anthos - deploys the google Bank of Anthos application to the EKS cluster
+              └─certmgr - deploys the open source cert-manager.io helm chart to the EKS cluster
+                └─anthos - deploys the google Bank of Anthos application to the EKS cluster
 ```
 
 ## Configuration
@@ -194,6 +195,13 @@ to the logstore deployed in the previous step. This solution can be
 swapped for other options as desired. This application is
 deployed to the `logagent` namespace.
 
+### Certificate Management
+
+TLS is enabled via [cert-manager](https://cert-manager.io/) which is installed in 
+the cert-manager namespace. Creation of ClusterIssuer or Issuer resources
+is delegated to the individual applications and is not done as part of this 
+deployment. 
+
 
 ### Demo Application
 
@@ -214,6 +222,13 @@ signing kay pair. This allows the user to take advantage Pulumi's feature
 set, by demonstrating the process of creating and deploying an RSA key pair
 at deployment time and using the project configuration file to set config
 variables, including secrets.
+
+As part of the Bank of Anthos deployment, we deploy a cluster-wide 
+[self-signed](https://cert-manager.io/docs/configuration/selfsigned/)
+issuer using the cert-manager deployed above. This is then used by the 
+Ingress object created to enable TLS access to the application. Note that
+this Issuer can be changed out by the user, for example to use the 
+[ACME](https://cert-manager.io/docs/configuration/acme/) issuer. 
 
 **Note** Due to the way that Pulumi currently handles secrets, the [anthos](./anthos)
 directory contains its own configuration direcotry [anthos/config](./anthos/config).

--- a/pulumi/aws/anthos/__main__.py
+++ b/pulumi/aws/anthos/__main__.py
@@ -269,27 +269,52 @@ selfissuer = ConfigFile(
 config = pulumi.Config('anthos')
 anthos_host = config.get('hostname')
 
-# If we have not defined a hostname in our config, we use the 
-# hostname of the LB.
+# If we have not defined a hostname in our config, we use the  hostname of the load
+# balancer. The default TLS uses self-signed certificates, so no hostname validation
+# is required. However, if the user makes use of ACME or other certificate authorities
+# the hostname chosen will need to resolve appropriately.
 if not anthos_host:
     anthos_host = lb_ingress_hostname
 
+# This block is responsible for creating the Ingress object for the application. This object
+# is deployed into the same namespace as the application and requires that an IngressClass
+# and Ingress controller be installed (which is done in an earlier step, deploying the KIC).
+#
+# Note that we are using an older version of the API (v1beta1) in order to accomodate older builds
+# of the KIC. This will be changed in the future and is being tracked by Issue #26
 boaingress = k8s.networking.v1beta1.Ingress("boaingress",
                                             api_version="networking.k8s.io/v1beta1",
                                             kind="Ingress",
                                             metadata=k8s.meta.v1.ObjectMetaArgs(
                                                 name="boaingress",
                                                 namespace=ns,
+                                                # This annotation is used to request a certificate from the cert
+                                                # manager. The manager watches for ingress objects with this
+                                                # annotation and handles certificate generation.
+                                                #
+                                                # It is possible to use different cert issuers with cert-manager,
+                                                # but in the current deployment we only have a self-signed issuer
+                                                # configured.
                                                 annotations={
                                                     "cert-manager.io/cluster-issuer": "selfsigned-issuer",
                                                 },
                                             ),
                                             spec=k8s.networking.v1beta1.IngressSpecArgs(
                                                 ingress_class_name="nginx",
+                                                # The block below sets up the TLS configuration for the Ingress
+                                                # controller. The secret defined here will be used by the issuer
+                                                # to store the generated certificate.
                                                 tls=[k8s.networking.v1beta1.IngressTLSArgs(
                                                     hosts=[lb_ingress_hostname],
                                                     secret_name="anthos-secret",
                                                 )],
+                                                # The block below defines the rules for traffic coming into the KIC.
+                                                # In the example below, we take any traffic on the host for path /
+                                                # and direct it to the frontend server on port 80. Additional routes
+                                                # could be added if desired. Also, different hostnames could be defined
+                                                # if desired. For example, an additional CNAME could be added to point
+                                                # to this same KIC along with a separate tls and host rule to direct
+                                                # traffic to a different backend.
                                                 rules=[k8s.networking.v1beta1.IngressRuleArgs(
                                                     host=lb_ingress_hostname,
                                                     http=k8s.networking.v1beta1.HTTPIngressRuleValueArgs(

--- a/pulumi/aws/anthos/cert/self-sign.yaml
+++ b/pulumi/aws/anthos/cert/self-sign.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned-issuer
+spec:
+  selfSigned: { }

--- a/pulumi/aws/certmgr/Pulumi.yaml
+++ b/pulumi/aws/certmgr/Pulumi.yaml
@@ -1,0 +1,7 @@
+name: certmgr
+runtime:
+  name: python
+  options:
+    virtualenv: ../venv
+config: ../config
+description: Sets up cert-manager.io 

--- a/pulumi/aws/certmgr/__main__.py
+++ b/pulumi/aws/certmgr/__main__.py
@@ -1,0 +1,59 @@
+import os
+
+import pulumi
+import pulumi_kubernetes as k8s
+import pulumi_kubernetes.helm.v3 as helm
+from pulumi_kubernetes.helm.v3 import FetchOpts
+
+from kic_util import pulumi_config
+
+CERTMGR_HELM_REPO_NAME = 'jetstack'
+CERTMGR_HELM_REPO_URL = 'https://charts.jetstack.io'
+
+
+# Removes the status field from the Nginx Ingress Helm Chart, so that i#t is
+# compatible with the Pulumi Chart implementation.
+def remove_status_field(obj):
+    if obj['kind'] == 'CustomResourceDefinition' and 'status' in obj:
+        del obj['status']
+
+
+def project_name_from_project_dir(dirname: str):
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    project_path = os.path.join(script_dir, '..', dirname)
+    return pulumi_config.get_pulumi_project_name(project_path)
+
+
+stack_name = pulumi.get_stack()
+project_name = pulumi.get_project()
+pulumi_user = pulumi_config.get_pulumi_user()
+
+eks_project_name = project_name_from_project_dir('eks')
+eks_stack_ref_id = f"{pulumi_user}/{eks_project_name}/{stack_name}"
+eks_stack_ref = pulumi.StackReference(eks_stack_ref_id)
+kubeconfig = eks_stack_ref.require_output('kubeconfig').apply(lambda c: str(c))
+
+k8s_provider = k8s.Provider(resource_name=f'ingress-setup-sample',
+                            kubeconfig=kubeconfig)
+
+ns = k8s.core.v1.Namespace(resource_name='cert-manager',
+                           metadata={'name': 'cert-manager'},
+                           opts=pulumi.ResourceOptions(provider=k8s_provider))
+
+chart_values = {
+    "installCRDs": True
+}
+
+chart_ops = helm.ChartOpts(
+    chart='cert-manager',
+    namespace=ns.metadata.name,
+    repo=CERTMGR_HELM_REPO_NAME,
+    fetch_opts=FetchOpts(repo=CERTMGR_HELM_REPO_URL),
+    version='v1.4.0',
+    values=chart_values,
+    transformations=[remove_status_field],
+)
+
+certmgr_chart = helm.Chart(release_name='certmgr',
+                           config=chart_ops,
+                           opts=pulumi.ResourceOptions(provider=k8s_provider, depends_on=[ns]))

--- a/pulumi/aws/certmgr/__main__.py
+++ b/pulumi/aws/certmgr/__main__.py
@@ -7,9 +7,6 @@ from pulumi_kubernetes.helm.v3 import FetchOpts
 
 from kic_util import pulumi_config
 
-CERTMGR_HELM_REPO_NAME = 'jetstack'
-CERTMGR_HELM_REPO_URL = 'https://charts.jetstack.io'
-
 
 # Removes the status field from the Nginx Ingress Helm Chart, so that i#t is
 # compatible with the Pulumi Chart implementation.
@@ -43,13 +40,27 @@ ns = k8s.core.v1.Namespace(resource_name='cert-manager',
 chart_values = {
     "installCRDs": True
 }
+helm_repo_name = 'jetstack'
+helm_repo_url = 'https://charts.jetstack.io'
+
+config = pulumi.Config('certmgr')
+chart_version = config.get('chart_version')
+if not chart_version:
+    chart_version = 'v1.4.0'
+helm_repo_name = config.get('certmgr_helm_repo_name')
+if not helm_repo_name:
+    helm_repo_name = 'jetstack'
+
+helm_repo_url = config.get('certmgr_helm_repo_url')
+if not helm_repo_url:
+    helm_repo_url = 'https://charts.jetstack.io'
 
 chart_ops = helm.ChartOpts(
     chart='cert-manager',
     namespace=ns.metadata.name,
-    repo=CERTMGR_HELM_REPO_NAME,
-    fetch_opts=FetchOpts(repo=CERTMGR_HELM_REPO_URL),
-    version='v1.4.0',
+    repo=helm_repo_name,
+    fetch_opts=FetchOpts(repo=helm_repo_url),
+    version=chart_version,
     values=chart_values,
     transformations=[remove_status_field],
 )

--- a/pulumi/aws/config/Pulumi.stackname.yaml.example
+++ b/pulumi/aws/config/Pulumi.stackname.yaml.example
@@ -73,4 +73,12 @@ config:
 
   # The parameters for the Bank of Anthos are set in a configuration directory
   # within that project. These values will be merged with that configuration.
-  #
+
+  # Cert Manager Configuration
+  certmgr:chart_version: v1.4.0
+  # Chart version for the Pulumi chart for certmanager
+  certmgr_helm_repo_name: jetstack
+  # Name of the repo to pull the certmanager chart from
+  certmgr_helm_repo_url: https://charts.jetstack.io
+  # URL of the chart repo to pull certmanager from
+

--- a/pulumi/aws/destroy.sh
+++ b/pulumi/aws/destroy.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
 
-set -o errexit   # abort on nonzero exit status
+#set -o errexit   # abort on nonzero exit status
 set -o nounset   # abort on unbound variable
 set -o pipefail  # don't hide errors within pipes
 
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 cd "${script_dir}/anthos"
+pulumi --emoji destroy --yes
+
+cd "${script_dir}/certmgr"
 pulumi --emoji destroy --yes
 
 cd "${script_dir}/logagent"

--- a/pulumi/aws/start_all.sh
+++ b/pulumi/aws/start_all.sh
@@ -199,6 +199,10 @@ header "Logagent"
 cd "${script_dir}/logagent"
 pulumi $pulumi_args up
 
+header "Cert Manager"
+cd "${script_dir}/certmgr"
+pulumi $pulumi_args up
+
 header "Bank of Anthos"
 cd "${script_dir}/anthos"
 pulumi $pulumi_args up


### PR DESCRIPTION
### Proposed changes
Add TLS support to the bank of anthos application, including an example ingress object using a self-signed cluster issuer resource. This requires adding cert-manager to the project as well. This can be used by additional ingress objects deployed as part of this framework.

This will close #6 

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [X] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [X] I have added tests (when possible) that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [X] I have updated necessary documentation
- [X] I have rebased my branch onto master
- [X] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
