### PR TITLE
fix: decrypt postgres password for use in connection string

### DIFF
--- a/pulumi/aws/README.md
+++ b/pulumi/aws/README.md
@@ -45,7 +45,7 @@ Since this project illustrates deploying to AWS,
 is necessary. If you want to avoid using environment variables, AWS profile
 and region definitions can be contained in the `config/Pulumi.<stack>.yaml` 
 files in each project. Refer to the Pulumi documentation for details on how to
-do this. The script [`startup_all.sh`](./startup_all.sh) will prompt you to add 
+do this. The script [`startup_all.sh`](./start_all.sh) will prompt you to add 
 the AWS region and profile values that will then be added to the `config/Pulumi.<stack>.yaml`
 in each project directory.
 
@@ -213,7 +213,7 @@ A version of the Google
 [_Bank of Anthos_](https://github.com/GoogleCloudPlatform/bank-of-anthos)
 application is contained in the [`anthos`](./anthos) directory. 
 
-Normally, the `frontend` micorservice is exposed via a load balancer for
+Normally, the `frontend` microservice is exposed via a load balancer for
 traffic management. This deployment has been modified to use the NGINX or
 NGINX Plus KIC to manage traffic to the `frontend` microservice. The NGINX
 or NGINX Plus KIC is integrated into the cluster logging system, and the 
@@ -235,15 +235,11 @@ this Issuer can be changed out by the user, for example to use the
 [ACME](https://cert-manager.io/docs/configuration/acme/) issuer. 
 
 **Note** Due to the way that Pulumi currently handles secrets, the [anthos](./anthos)
-directory contains its own configuration direcotry [anthos/config](./anthos/config).
-This directory contains an example configuration file that is merged with the base
-configuration file created for the stack under [config](./config) by the startup 
-script [start_all.sh](./start_all.sh). This merge and prompt for passwords to add to 
-the configuratoin file only occurs on the first run; if the configuration exists the 
-logic in the startup script will leave it as-is. It is possible to re-merge the files
-by deleting the stack config file under [anthos/config](./anthos/config). This is a 
-work-around that will be retired as Pulumi provides better tools for hierarchtical
-configuration files.
+directory contains its own configuration directory [anthos/config](./anthos/config).
+This directory contains an example configuration file that can be copied over
+and used. The user will be prompted to add passwords to the configuration file at the
+first run of the [start_all.sh](./start_all.sh) script. This is a work-around that 
+will be retired as Pulumi provides better tools for hierarchical configuration files.
 
 
 

--- a/pulumi/aws/anthos/config/Pulumi.stackname.yaml.example
+++ b/pulumi/aws/anthos/config/Pulumi.stackname.yaml.example
@@ -8,18 +8,9 @@ config:
   anthos:ledger_admin: admin
   anthos:ledger_db: postgresdb
 
-  # These parameters define the credentials for the demo user for the Bank of Anthos
-  # application as well as defining if the demo data should be loaded.
-  #
-  # Note that the encrypted password is a required value; Pulumi will abort the Bank of Anthos
-  # deployment if no password is provided.
-  #anthos:demo_pwd: password # Required
-  anthos:demo_login: testuser
-  anthos:demo_data: True
-
   # This optional parameter supplies a hostname for the Bank of Anthos Ingress
   # controller. If not set, the FQDN of the LB is used.
-  anthos:hostname: demo.example.com
+  #anthos:hostname: demo.example.com
 
   # These parameters define the name of the database and the database credentials
   # used by the Bank of Anthos accounts application.

--- a/pulumi/aws/config/Pulumi.stackname.yaml.example
+++ b/pulumi/aws/config/Pulumi.stackname.yaml.example
@@ -72,7 +72,7 @@ config:
     kic:cert_path: /etc/ssl/nginx/nginx-repo.crt
 
   # The parameters for the Bank of Anthos are set in a configuration directory
-  # within that project. These values will be merged with that configuration.
+  # within that project.
 
   # Cert Manager Configuration
   certmgr:chart_version: v1.4.0

--- a/pulumi/aws/start_all.sh
+++ b/pulumi/aws/start_all.sh
@@ -78,39 +78,16 @@ else
   echo "Using AWS_DEFAULT_REGION from environment/config: ${AWS_DEFAULT_REGION}"
 fi
 
-# If it does not already exist we will create the configuration file for the 
-# bank of anthos application.
-# 
-# This is done by merging the main config file with the configuration 
-# file from the main config.
+# The bank of anthos configuration file is stored in the ./anthos/config
+# directory. This is because we cannot pull secrets from different project
+# directories.
 #
-# This is a work-around, as we are using a common configuration file for
-# the project but secrets are encrypted at the stack/project level.
-#
-# The logic is
-# 1. If a configuration file of the format ./config/Pulumi.stackname.yaml
-#    exists in the Anthos directory we just check for the secrets.
-# 2. If the file does not exist, we create a file by merging the contents
-#    of the top level config file (Pulumi.stackname.yaml) with the template
-#    file in the Anthos directory (./config/Pulumi.stackname.yaml.example)
-#    to create ./config/Pulumi.stackname.yaml.
-# 
-# To fully recreate the file (including re-adding the passwords) you can 
-# remove the ./config/Pulumi.stackname.yaml file and re-run this script.
-#
-# This work-around is expected to be obsoleted by the work described in 
+# This work-around is expected to be obsoleted by the work described in
 # https://github.com/pulumi/pulumi/issues/4604, specifically around issue
 # https://github.com/pulumi/pulumi/issues/2307
 #
-if [ ! -f "${script_dir}/anthos/config/Pulumi.${PULUMI_STACK}.yaml" ]; then
-    echo "Merging master config with Bank of Anthos config"
-    ${script_dir}/venv/bin/yamlreader ${script_dir}/config/Pulumi.${PULUMI_STACK}.yaml ${script_dir}/anthos/config/Pulumi.stackname.yaml.example  > \
-    ${script_dir}/anthos/config/Pulumi.${PULUMI_STACK}.yaml
-else
-    echo "Bank of Anthos config exists"
-fi
-
 # Check for secrets being set
+#
 echo "Checking for required secrets"
 
 # Anthos Accounts Database

--- a/pulumi/aws/start_all.sh
+++ b/pulumi/aws/start_all.sh
@@ -106,14 +106,6 @@ else
   pulumi config set --secret anthos:ledger_pwd -C ${script_dir}/anthos
 fi
 
-# Demo Account
-if pulumi config get anthos:demo_pwd -C ${script_dir}/anthos > /dev/null 2>&1; then
-  echo "Password found for anthos demo account"
-else
-  echo "Create a password for the anthos demo application; you will need this to log in"
-  pulumi config set --secret anthos:demo_pwd -C ${script_dir}/anthos
-fi
-
 # Show colorful fun headers if the right utils are installed
 function header() {
   "${script_dir}"/venv/bin/fart --no_copy -f standard "$1" | "${script_dir}"/venv/bin/lolcat


### PR DESCRIPTION
### Proposed changes
This addresses a bug introduced with #30 - the password is part of the connection string, but pulumi does not decrypt it for use in the string concatenation needed to build it. This has been fixed by using the `Output.unsecret` method.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [X] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [X] I have added tests (when possible) that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [X] I have updated necessary documentation
- [X] I have rebased my branch onto master
- [X] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
