### PR TITLE
feat: move to beta pulumi k8 sdk to migrate to helm releases

### DIFF
--- a/pulumi/aws/certmgr/__main__.py
+++ b/pulumi/aws/certmgr/__main__.py
@@ -2,17 +2,9 @@ import os
 
 import pulumi
 import pulumi_kubernetes as k8s
-import pulumi_kubernetes.helm.v3 as helm
-from pulumi_kubernetes.helm.v3 import FetchOpts
+from pulumi_kubernetes.helm.v3 import Release, ReleaseArgs, RepositoryOptsArgs
 
 from kic_util import pulumi_config
-
-
-# Removes the status field from the Nginx Ingress Helm Chart, so that i#t is
-# compatible with the Pulumi Chart implementation.
-def remove_status_field(obj):
-    if obj['kind'] == 'CustomResourceDefinition' and 'status' in obj:
-        del obj['status']
 
 
 def project_name_from_project_dir(dirname: str):
@@ -37,10 +29,6 @@ ns = k8s.core.v1.Namespace(resource_name='cert-manager',
                            metadata={'name': 'cert-manager'},
                            opts=pulumi.ResourceOptions(provider=k8s_provider))
 
-chart_values = {
-    "installCRDs": True
-}
-
 config = pulumi.Config('certmgr')
 chart_name = config.get('chart_name')
 if not chart_name:
@@ -56,16 +44,31 @@ helm_repo_url = config.get('certmgr_helm_repo_url')
 if not helm_repo_url:
     helm_repo_url = 'https://charts.jetstack.io'
 
-chart_ops = helm.ChartOpts(
+certmgr_release_args = ReleaseArgs(
     chart=chart_name,
-    namespace=ns.metadata.name,
-    repo=helm_repo_name,
-    fetch_opts=FetchOpts(repo=helm_repo_url),
+    repository_opts=RepositoryOptsArgs(
+        repo=helm_repo_url
+    ),
     version=chart_version,
-    values=chart_values,
-    transformations=[remove_status_field],
-)
+    namespace=ns.metadata.name,
 
-certmgr_chart = helm.Chart(release_name='certmgr',
-                           config=chart_ops,
-                           opts=pulumi.ResourceOptions(provider=k8s_provider, depends_on=[ns]))
+    # Values from Chart's parameters specified hierarchically,
+    values={
+        "installCRDs": True
+    },
+    # By default Release resource will wait till all created resources
+    # are available. Set this to true to skip waiting on resources being
+    # available.
+    skip_await=False,
+    # If we fail, clean up 
+    cleanup_on_fail=True,
+    # Provide a name for our release
+    name="certmgr",
+    # Lint the chart before installing
+    lint=True,
+    # Force update if required
+    force_update=True)
+certmgr_release = Release("certmgr", args=certmgr_release_args)
+
+status = certmgr_release.status
+pulumi.export("Certmgr Status", status)

--- a/pulumi/aws/certmgr/__main__.py
+++ b/pulumi/aws/certmgr/__main__.py
@@ -71,4 +71,4 @@ certmgr_release_args = ReleaseArgs(
 certmgr_release = Release("certmgr", args=certmgr_release_args)
 
 status = certmgr_release.status
-pulumi.export("Certmgr Status", status)
+pulumi.export("certmgr_status", status)

--- a/pulumi/aws/grafana/__main__.py
+++ b/pulumi/aws/grafana/__main__.py
@@ -136,4 +136,4 @@ grafana_release_args = ReleaseArgs(
 grafana_release = Release("grafana", args=grafana_release_args)
 
 status = grafana_release.status
-pulumi.export("Grafana Status", status)
+pulumi.export("grafana_status", status)

--- a/pulumi/aws/grafana/__main__.py
+++ b/pulumi/aws/grafana/__main__.py
@@ -2,23 +2,21 @@ import os
 
 import pulumi
 import pulumi_kubernetes as k8s
-import pulumi_kubernetes.helm.v3 as helm
-from pulumi_kubernetes.helm.v3 import FetchOpts
+from pulumi_kubernetes.helm.v3 import Release, ReleaseArgs, RepositoryOptsArgs
 
 from kic_util import pulumi_config
-
-
-# Removes the status field from the Helm Chart, so that it is
-# compatible with the Pulumi Chart implementation.
-def remove_status_field(obj):
-    if obj['kind'] == 'CustomResourceDefinition' and 'status' in obj:
-        del obj['status']
 
 
 def project_name_from_project_dir(dirname: str):
     script_dir = os.path.dirname(os.path.abspath(__file__))
     project_path = os.path.join(script_dir, '..', dirname)
     return pulumi_config.get_pulumi_project_name(project_path)
+
+
+def pulumi_prometheus_project_name():
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    prometheus_project_path = os.path.join(script_dir, '..', 'prometheus')
+    return pulumi_config.get_pulumi_project_name(prometheus_project_path)
 
 
 stack_name = pulumi.get_stack()
@@ -38,7 +36,6 @@ ns = k8s.core.v1.Namespace(resource_name='grafana',
                            opts=pulumi.ResourceOptions(provider=k8s_provider))
 
 config = pulumi.Config('grafana')
-
 adminuser = config.get('admin_user')
 if not adminuser:
     adminuser = 'admin'
@@ -48,56 +45,6 @@ if not adminuser:
 # same time that we fix the Anthos issues.
 adminpass = config.require('adminpass')
 
-chart_values = {
-    'persistence': {
-        'enabled': True
-    },
-    'adminUser': adminuser,
-    'adminPassword': adminpass,
-    "datasources": {
-        "datasources.yaml": {
-            "apiVersion": 1,
-            "datasources": [
-                {
-                    "name": "Prometheus",
-                    "type": "prometheus",
-                    "url": "http://prometheus-server.prometheus.svc.cluster.local:80",
-                    "access": "proxy",
-                    "isDefault": True
-                }
-            ]
-        }
-    },
-    "dashboardProviders": {
-        "dashboardproviders.yaml": {
-            "apiVersion": 1,
-            "providers": [
-                {
-                    "name": "default",
-                    "orgId": 1,
-                    "folder": "",
-                    "type": "file",
-                    "disableDeletion": False,
-                    "editable": True,
-                    "options": {
-                        "path": "/var/lib/grafana/dashboards/default"
-                    }
-                }
-            ]
-        }
-    },
-    "dashboards": {
-        "default": {
-            "local-dashboard": {
-                "url": "https://raw.githubusercontent.com/nginxinc/kubernetes-ingress/master/grafana/NGINXPlusICDashboard.json",
-                "token": "",
-                "datasoure": "Prometheus"
-            }
-        }
-    }
-}
-
-config = pulumi.Config('grafana')
 chart_name = config.get('chart_name')
 if not chart_name:
     chart_name = 'grafana'
@@ -111,16 +58,82 @@ helm_repo_url = config.get('grafana_helm_repo_url')
 if not helm_repo_url:
     helm_repo_url = 'https://grafana.github.io/helm-charts'
 
-chart_ops = helm.ChartOpts(
-    chart=chart_name,
-    namespace=ns.metadata.name,
-    repo=helm_repo_name,
-    fetch_opts=FetchOpts(repo=helm_repo_url),
-    version=chart_version,
-    values=chart_values,
-    transformations=[remove_status_field]
-)
+# Logic to extract the FQDN of prometheus
+prometheus_project_name = pulumi_prometheus_project_name()
+prometheus_stack_ref_id = f"{pulumi_user}/{prometheus_project_name}/{stack_name}"
+prometheus_stack_ref = pulumi.StackReference(prometheus_stack_ref_id)
+prometheus_hostname = prometheus_stack_ref.get_output('prometheus_hostname')
 
-grafana_chart = helm.Chart(release_name='grafana',
-                           config=chart_ops,
-                           opts=pulumi.ResourceOptions(provider=k8s_provider))
+grafana_release_args = ReleaseArgs(
+    chart=chart_name,
+    repository_opts=RepositoryOptsArgs(
+        repo=helm_repo_url
+    ),
+    version=chart_version,
+    namespace=ns.metadata.name,
+
+    # Values from Chart's parameters specified hierarchically,
+    values={
+        'persistence': {
+            'enabled': True
+        },
+        'adminUser': adminuser,
+        'adminPassword': adminpass,
+        "datasources": {
+            "datasources.yaml": {
+                "apiVersion": 1,
+                "datasources": [
+                    {
+                        "name": "Prometheus",
+                        "type": "prometheus",
+                        "url": "http://prometheus-server.prometheus.svc.cluster.local:80",
+                        "access": "proxy",
+                        "isDefault": True
+                    }
+                ]
+            }
+        },
+        "dashboardProviders": {
+            "dashboardproviders.yaml": {
+                "apiVersion": 1,
+                "providers": [
+                    {
+                        "name": "default",
+                        "orgId": 1,
+                        "folder": "",
+                        "type": "file",
+                        "disableDeletion": False,
+                        "editable": True,
+                        "options": {
+                            "path": "/var/lib/grafana/dashboards/default"
+                        }
+                    }
+                ]
+            }
+        },
+        "dashboards": {
+            "default": {
+                "local-dashboard": {
+                    "url": "https://raw.githubusercontent.com/nginxinc/kubernetes-ingress/master/grafana/NGINXPlusICDashboard.json",
+                    "token": "",
+                    "datasoure": "Prometheus"
+                }
+            }
+        }
+    },
+    # By default Release resource will wait till all created resources
+    # are available. Set this to true to skip waiting on resources being
+    # available.
+    skip_await=False,
+    # If we fail, clean up 
+    cleanup_on_fail=True,
+    # Provide a name for our release
+    name="grafana",
+    # Lint the chart before installing
+    lint=True,
+    # Force update if required
+    force_update=True)
+grafana_release = Release("grafana", args=grafana_release_args)
+
+status = grafana_release.status
+pulumi.export("Grafana Status", status)

--- a/pulumi/aws/kic-helm-chart/__main__.py
+++ b/pulumi/aws/kic-helm-chart/__main__.py
@@ -149,4 +149,4 @@ ingress_service = srv.status
 
 pulumi.export('lb_ingress_hostname', pulumi.Output.unsecret(ingress_service.load_balancer.ingress[0].hostname))
 # Print out our status
-pulumi.export("KIC Status", pstatus)
+pulumi.export("kic_status", pstatus)

--- a/pulumi/aws/logagent/__main__.py
+++ b/pulumi/aws/logagent/__main__.py
@@ -96,4 +96,4 @@ filebeat_release_args = ReleaseArgs(
 filebeat_release = Release("filebeat", args=filebeat_release_args)
 
 status = filebeat_release.status
-pulumi.export("Logagent Status", status)
+pulumi.export("logagent_status", status)

--- a/pulumi/aws/logagent/__main__.py
+++ b/pulumi/aws/logagent/__main__.py
@@ -2,8 +2,7 @@ import os
 
 import pulumi
 import pulumi_kubernetes as k8s
-import pulumi_kubernetes.helm.v3 as helm
-from pulumi_kubernetes.helm.v3 import FetchOpts
+from pulumi_kubernetes.helm.v3 import Release, ReleaseArgs, RepositoryOptsArgs
 
 from kic_util import pulumi_config
 
@@ -20,12 +19,6 @@ if not helm_repo_name:
 helm_repo_url = config.get('helm_repo_url')
 if not helm_repo_url:
     helm_repo_url = 'https://helm.elastic.co'
-
-# Removes the status field from the Helm Chart, so that it is
-# compatible with the Pulumi Chart implementation.
-def remove_status_field(obj):
-    if obj['kind'] == 'CustomResourceDefinition' and 'status' in obj:
-        del obj['status']
 
 
 def project_name_from_project_dir(dirname: str):
@@ -50,25 +43,29 @@ ns = k8s.core.v1.Namespace(resource_name='logagent',
                            metadata={'name': 'logagent'},
                            opts=pulumi.ResourceOptions(provider=k8s_provider))
 
-chart_values = {
-    "daemonset": {
-        "enabled": True,
-        "filebeatConfig": {
-            "filebeat.yml": "setup.kibana.host: 'http://elastic-kibana.logstore.svc.cluster.local:5601'\nsetup.dashboards.enabled: true\nfilebeat.autodiscover:\n  providers:\n    - type: kubernetes\n      hints.enabled: true\n      hints.default_config:\n        type: container\n        paths:\n          - /var/lib/docker/containers/${data.kubernetes.container.id}/*.log\noutput.elasticsearch:\n  host: '${NODE_NAME}'\n  hosts: 'elastic-coordinating-only.logstore.svc.cluster.local:9200'\n"
-        }
-    }
-}
-
-chart_ops = helm.ChartOpts(
+filebeat_release_args = ReleaseArgs(
     chart=chart_name,
-    namespace=ns.metadata.name,
-    repo=helm_repo_name,
-    fetch_opts=FetchOpts(repo=helm_repo_url),
+    repository_opts=RepositoryOptsArgs(
+        repo=helm_repo_url
+    ),
     version=chart_version,
-    values=chart_values,
-    transformations=[remove_status_field]
-)
+    namespace=ns.metadata.name,
 
-filebeat_chart = helm.Chart(release_name='filebeat',
-                            config=chart_ops,
-                            opts=pulumi.ResourceOptions(provider=k8s_provider))
+    # Values from Chart's parameters specified hierarchically,
+    values={
+        "daemonset": {
+            "enabled": True,
+            "filebeatConfig": {
+                "filebeat.yml": "setup.kibana.host: 'http://elastic-kibana.logstore.svc.cluster.local:5601'\nsetup.dashboards.enabled: true\nfilebeat.autodiscover:\n  providers:\n    - type: kubernetes\n      hints.enabled: true\n      hints.default_config:\n        type: container\n        paths:\n          - /var/lib/docker/containers/${data.kubernetes.container.id}/*.log\noutput.elasticsearch:\n  host: '${NODE_NAME}'\n  hosts: 'elastic-coordinating-only.logstore.svc.cluster.local:9200'\n"
+            }
+        }
+    },
+    # By default Release resource will wait till all created resources
+    # are available. Set this to true to skip waiting on resources being
+    # available.
+    skip_await=False)
+
+filebeat_release = Release("filebeat", args=filebeat_release_args)
+
+status = filebeat_release.status
+pulumi.export("Status", status)

--- a/pulumi/aws/logstore/__main__.py
+++ b/pulumi/aws/logstore/__main__.py
@@ -3,7 +3,6 @@ import os
 import pulumi
 import pulumi_kubernetes as k8s
 from pulumi import Output
-from pulumi_kubernetes.core.v1 import Namespace, Service
 from pulumi_kubernetes.helm.v3 import Release, ReleaseArgs, RepositoryOptsArgs
 
 from kic_util import pulumi_config
@@ -65,7 +64,15 @@ elastic_release_args = ReleaseArgs(
     # By default Release resource will wait till all created resources
     # are available. Set this to true to skip waiting on resources being
     # available.
-    skip_await=False)
+    skip_await=False,
+    # If we fail, clean up 
+    cleanup_on_fail=True,
+    # Provide a name for our release
+    name="elastic",
+    # Lint the chart before installing
+    lint=True,
+    # Force update if required
+    force_update=True)
 
 elastic_release = Release("elastic", args=elastic_release_args)
 
@@ -77,3 +84,6 @@ kibana_fqdn = Output.concat(elastic_rname, "-kibana.logstore.svc.cluster.local")
 pulumi.export('elastic_hostname', pulumi.Output.unsecret(elastic_fqdn))
 pulumi.export('kibana_hostname', pulumi.Output.unsecret(kibana_fqdn))
 
+# Print out our status
+estatus = elastic_release.status
+pulumi.export("Logstore Status", estatus)

--- a/pulumi/aws/logstore/__main__.py
+++ b/pulumi/aws/logstore/__main__.py
@@ -2,6 +2,8 @@ import os
 
 import pulumi
 import pulumi_kubernetes as k8s
+from pulumi import Output
+from pulumi_kubernetes.core.v1 import Namespace, Service
 from pulumi_kubernetes.helm.v3 import Release, ReleaseArgs, RepositoryOptsArgs
 
 from kic_util import pulumi_config
@@ -67,5 +69,11 @@ elastic_release_args = ReleaseArgs(
 
 elastic_release = Release("elastic", args=elastic_release_args)
 
-status = elastic_release.status
-pulumi.export("Status", status)
+elastic_rname = elastic_release.status.name
+
+elastic_fqdn = Output.concat(elastic_rname, "-coordinating-only.logstore.svc.cluster.local")
+kibana_fqdn = Output.concat(elastic_rname, "-kibana.logstore.svc.cluster.local")
+
+pulumi.export('elastic_hostname', pulumi.Output.unsecret(elastic_fqdn))
+pulumi.export('kibana_hostname', pulumi.Output.unsecret(kibana_fqdn))
+

--- a/pulumi/aws/logstore/__main__.py
+++ b/pulumi/aws/logstore/__main__.py
@@ -86,4 +86,4 @@ pulumi.export('kibana_hostname', pulumi.Output.unsecret(kibana_fqdn))
 
 # Print out our status
 estatus = elastic_release.status
-pulumi.export("Logstore Status", estatus)
+pulumi.export("logstat_status", estatus)

--- a/pulumi/aws/logstore/__main__.py
+++ b/pulumi/aws/logstore/__main__.py
@@ -66,3 +66,6 @@ elastic_release_args = ReleaseArgs(
     skip_await=False)
 
 elastic_release = Release("elastic", args=elastic_release_args)
+
+status = elastic_release.status
+pulumi.export("Status", status)

--- a/pulumi/aws/prometheus/__main__.py
+++ b/pulumi/aws/prometheus/__main__.py
@@ -58,7 +58,14 @@ prometheus_release_args = ReleaseArgs(
     # By default Release resource will wait till all created resources
     # are available. Set this to true to skip waiting on resources being
     # available.
-    skip_await=False)
+    skip_await=False,
+    cleanup_on_fail=True,
+    # Provide a name for our release
+    name="prometheus",
+    # Lint the chart before installing
+    lint=True,
+    # Force update if required
+    force_update=True)
 
 prometheus_release = Release("prometheus", args=prometheus_release_args)
 
@@ -110,7 +117,15 @@ statsd_release_args = ReleaseArgs(
     # By default Release resource will wait till all created resources
     # are available. Set this to true to skip waiting on resources being
     # available.
-    skip_await=False)
+    skip_await=False,
+    # If we fail, clean up 
+    cleanup_on_fail=True,
+    # Provide a name for our release
+    name="statsd",
+    # Lint the chart before installing
+    lint=True,
+    # Force update if required
+    force_update=True)
 
 statsd_release = Release("statsd", args=statsd_release_args)
 

--- a/pulumi/aws/prometheus/__main__.py
+++ b/pulumi/aws/prometheus/__main__.py
@@ -132,8 +132,8 @@ statsd_release = Release("statsd", args=statsd_release_args)
 statsd_status = statsd_release.status
 
 # Print out our status
-pulumi.export("Prometheus Status", prom_status)
-pulumi.export("Statsd Status", statsd_status)
+pulumi.export("prom_status", prom_status)
+pulumi.export("statsd_status", statsd_status)
 
 prom_rname = prometheus_release.status.name
 

--- a/pulumi/aws/prometheus/__main__.py
+++ b/pulumi/aws/prometheus/__main__.py
@@ -3,6 +3,7 @@ import os
 import pulumi
 import pulumi_kubernetes as k8s
 from pulumi_kubernetes.helm.v3 import Release, ReleaseArgs, RepositoryOptsArgs
+from pulumi import Output
 
 from kic_util import pulumi_config
 
@@ -118,3 +119,9 @@ statsd_status = statsd_release.status
 # Print out our status
 pulumi.export("Prometheus Status", prom_status)
 pulumi.export("Statsd Status", statsd_status)
+
+prom_rname = prometheus_release.status.name
+
+prom_fqdn = Output.concat(prom_rname, "-prometheus-server.prometheus.svc.cluster.local")
+
+pulumi.export('prom_hostname', pulumi.Output.unsecret(prom_fqdn))

--- a/pulumi/aws/sirius/__main__.py
+++ b/pulumi/aws/sirius/__main__.py
@@ -446,5 +446,5 @@ ledgerdb_release = Release("ledgerdb", args=ledgerdb_release_args)
 
 ledgerdb_status = ledgerdb_release.status
 
-pulumi.export("Ledgerdb PromMon Status", accountsdb_status)
-pulumi.export("Accountsdb PromMon Status", ledgerdb_status)
+pulumi.export("ledgerdbmon_status", accountsdb_status)
+pulumi.export("accountsdbmon_status", ledgerdb_status)

--- a/pulumi/aws/sirius/__main__.py
+++ b/pulumi/aws/sirius/__main__.py
@@ -414,39 +414,6 @@ ledgerdb_release_args = ReleaseArgs(
 
     # Values from Chart's parameters specified hierarchically,
     values={
-        "replicaCount": 1,
-        "image": {
-            "repository": "quay.io/prometheuscommunity/postgres-exporter",
-            "tag": "v0.9.0",
-            "pullPolicy": "IfNotPresent"
-        },
-        "service": {
-            "type": "ClusterIP",
-            "port": 80,
-            "targetPort": 9187,
-            "name": "http",
-            "labels": {},
-            "annotations": {}
-        },
-        "serviceMonitor": {
-            "enabled": False
-        },
-        "prometheusRule": {
-            "enabled": False,
-            "additionalLabels": {},
-            "namespace": "",
-            "rules": []
-        },
-        "resources": {},
-        "rbac": {
-            "create": True,
-            "pspEnabled": True
-        },
-        "serviceAccount": {
-            "create": True,
-            "annotations": {}
-        },
-        "securityContext": {},
         "config": {
             "datasource": {
                 "host": "ledger-db",
@@ -456,35 +423,11 @@ ledgerdb_release_args = ReleaseArgs(
                 "port": "5432",
                 "database": ledger_db,
                 "sslmode": "disable"
-            },
-            "datasourceSecret": {},
-            "disableDefaultMetrics": False,
-            "disableSettingsMetrics": False,
-            "autoDiscoverDatabases": False,
-            "excludeDatabases": [],
-            "includeDatabases": [],
-            "constantLabels": {},
-            "logLevel": ""
+            }
         },
-        "nodeSelector": {},
-        "tolerations": [],
-        "affinity": {},
         "annotations": {
             "prometheus.io/scrape": "true",
-            "prometheus.io/port": "9187"},
-        "podLabels": {},
-        "livenessProbe": {
-            "initialDelaySeconds": 0,
-            "timeoutSeconds": 1
-        },
-        "readinessProbe": {
-            "initialDelaySeconds": 0,
-            "timeoutSeconds": 1
-        },
-        "initContainers": [],
-        "extraContainers": [],
-        "extraVolumes": [],
-        "extraVolumeMounts": []
+            "prometheus.io/port": "9187"}
     },
     # By default Release resource will wait till all created resources
     # are available. Set this to true to skip waiting on resources being


### PR DESCRIPTION
### Proposed changes
Currently, MARA uses helm charts within pulumi. This approach works, but has some drawbacks as pulumi is not executing helm directly but instead is using the data in the helm chart to provision resources. The new (as of SDK 3.7+) release approach uses the helm SDK, which provides a great deal more flexibility.

This change cuts all the projects that use helm.chart over to helm.release, and adds some additional logging, error checking, and cleanup around the charts. We now lint the charts before we run them, and we rollback and cleanup any failures.

This has also changed the way we pull the hostname of the ELB; this logic may need to be adjusted for environments where a hostname is not provided and an IP is returned instead.

Testing is still underway; this change may require that we install helm3 in the venv, but that is yet to be determined.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [X] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [X] I have added tests (when possible) that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [X] I have updated necessary documentation
- [X] I have rebased my branch onto master
- [X] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
