### PR TITLE
fix: update logic for FQDN and double helm timeout for kubeconfig deploy

### DIFF
--- a/bin/start_kube.sh
+++ b/bin/start_kube.sh
@@ -253,6 +253,21 @@ else
   pulumi config set prometheus:adminpass -C ${script_dir}/../pulumi/python/config
 fi
 
+#
+# TODO: Allow startup scripts to prompt and accept additional config values #97
+# The default helm timeout for all of the projects is set at the default of 300 seconds (5 minutes)
+# However, since this code path is most commonly going to be used to deploy locally we need to bump
+# that value up. A fix down the road will add this a prompt, but for now we are going to double this
+# value for all helm deploys.
+#
+
+pulumi config set kic-helm:helm_timeout 600 -C ${script_dir}/../pulumi/python/config
+pulumi config set logagent:helm_timeout 600 -C ${script_dir}/../pulumi/python/config
+pulumi config set logstore:helm_timeout 600 -C ${script_dir}/../pulumi/python/config
+pulumi config set certmgr:helm_timeout 600 -C ${script_dir}/../pulumi/python/config
+pulumi config set prometheus:helm_timeout 600 -C ${script_dir}/../pulumi/python/config
+
+
 pulumi_args="--emoji --stack ${PULUMI_STACK}"
 
 header "Kubeconfig"

--- a/bin/start_kube.sh
+++ b/bin/start_kube.sh
@@ -208,7 +208,7 @@ fi
 # deployed, and will output the IP address and the hostname that will need to be set in order to use the self-signed
 # cert and to access the application.
 #
-if pulumi config get sirius:fqdn -C ${script_dir}/../pulumi/python/kubernetes/applications/sirius >/dev/null 2>&1; then
+if pulumi config get kic-helm:fqdn -C ${script_dir}/../pulumi/python/config >/dev/null 2>&1; then
   echo "Hostname found for deployment"
 else
   echo "Create a fqdn for your deployment"


### PR DESCRIPTION
### Proposed changes
We have two deployment routes, one for AWS and one for Kubeconfig currently. The later is usually used with locally hosted (and therefore less responsive) K8 installations. Becuase of this we are hitting the timeout on the helm charts (300 secs) quite frequently. There is an issue open to allow for the timeouts to be adjusted as part of the start.sh process (#97 ) but for now we are going to just set them to 600 secs for these deploys. This can always be adjusted in the config file by the user.

The FQDN is a simple bug fix that I noticed while implementing the above.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [X] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [X] I have added tests (when possible) that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [X] I have updated necessary documentation
- [X] I have rebased my branch onto master
- [X] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
