### PR TITLE
fix: add a NS dependency in IC deployment

### DIFF
--- a/pulumi/python/kubernetes/nginx/ingress-controller-repo-only/__main__.py
+++ b/pulumi/python/kubernetes/nginx/ingress-controller-repo-only/__main__.py
@@ -169,7 +169,7 @@ kic_release_args = ReleaseArgs(
     # Force update if required
     force_update=True)
 
-kic_chart = Release("kic", args=kic_release_args)
+kic_chart = Release("kic", args=kic_release_args, opts=pulumi.ResourceOptions(depends_on=[ns]))
 
 pstatus = kic_chart.status
 

--- a/pulumi/python/kubernetes/nginx/ingress-controller/__main__.py
+++ b/pulumi/python/kubernetes/nginx/ingress-controller/__main__.py
@@ -178,7 +178,7 @@ kic_release_args = ReleaseArgs(
     # Force update if required
     force_update=True)
 
-kic_chart = Release("kic", args=kic_release_args)
+kic_chart = Release("kic", args=kic_release_args, opts=pulumi.ResourceOptions(depends_on=[ns]))
 
 pstatus = kic_chart.status
 


### PR DESCRIPTION
### Proposed changes
While doing testing, we noticed that there would be a transient warning during the IC deployment about the namespace not being ready. Checking into the code, we see that we don't have an explicit dependence on the namespace for the helm deployment. This usually is just annoying in that pulumi will retry, but on older or slower clusters this may lead to a timeout. This update fixes that hole.

Passes build/deploy in AWS, K3S, and MicroK8s.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [X] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [X] I have added tests (when possible) that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [X] I have updated necessary documentation
- [X] I have rebased my branch onto master
- [X] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
