### PR TITLE
Add DigitalOcean Support

### DIFF
--- a/bin/destroy.sh
+++ b/bin/destroy.sh
@@ -81,6 +81,11 @@ if pulumi config get kubernetes:infra_type -C ${script_dir}/../pulumi/python/con
     sleep 5
     ${script_dir}/destroy_kube.sh
     exit 0
+  elif [ $INFRA == 'DO' ]; then
+    echo "Destroying a Digital Ocean based stack; if this is not right please type ctrl-c to abort this script."
+    sleep 5
+    ${script_dir}/destroy_do.sh
+    exit 0
   else
     print "No infrastructure set in config file; aborting!"
     exit 1

--- a/bin/destroy_do.sh
+++ b/bin/destroy_do.sh
@@ -63,6 +63,7 @@ echo "Configuring all Pulumi projects to use the stack: ${PULUMI_STACK}"
 APPLICATIONS=(sirius)
 KUBERNETES=(observability logagent logstore certmgr prometheus)
 NGINX=(kubernetes/nginx/ingress-controller-repo-only)
+INFRA=(kubeconfig digitalocean/domk8s)
 
 #
 # This is a temporary process until we complete the directory reorg and move the start/stop
@@ -115,7 +116,7 @@ for project_dir in "${NGINX[@]}" ; do
 done
 
 # Clean up the kubeconfig project
-for project_dir in "kubeconfig digitalocean/domk8s" ; do
+for project_dir in "${INFRA[@]}" ; do
   echo "$project_dir"
   if [ -f "${script_dir}/../pulumi/python/infrastructure/${project_dir}/Pulumi.yaml" ]; then
     pulumi_args="--cwd ${script_dir}/../pulumi/python/infrastructure/${project_dir} --emoji --stack ${PULUMI_STACK}"
@@ -124,7 +125,3 @@ for project_dir in "kubeconfig digitalocean/domk8s" ; do
     >&2 echo "Not destroying - Pulumi.yaml not found in directory: ${script_dir}/../pulumi/python/infrastructure/${project_dir}"
   fi
 done
-
-
-
-

--- a/bin/destroy_do.sh
+++ b/bin/destroy_do.sh
@@ -63,7 +63,6 @@ echo "Configuring all Pulumi projects to use the stack: ${PULUMI_STACK}"
 APPLICATIONS=(sirius)
 KUBERNETES=(observability logagent logstore certmgr prometheus)
 NGINX=(kubernetes/nginx/ingress-controller-repo-only)
-INFRA=(kubeconfig digitalocean/domk8s)
 
 #
 # This is a temporary process until we complete the directory reorg and move the start/stop
@@ -116,7 +115,7 @@ for project_dir in "${NGINX[@]}" ; do
 done
 
 # Clean up the kubeconfig project
-for project_dir in "${INFRA[@]}" ; do
+for project_dir in "kubeconfig" ; do
   echo "$project_dir"
   if [ -f "${script_dir}/../pulumi/python/infrastructure/${project_dir}/Pulumi.yaml" ]; then
     pulumi_args="--cwd ${script_dir}/../pulumi/python/infrastructure/${project_dir} --emoji --stack ${PULUMI_STACK}"

--- a/bin/destroy_do.sh
+++ b/bin/destroy_do.sh
@@ -115,7 +115,7 @@ for project_dir in "${NGINX[@]}" ; do
 done
 
 # Clean up the kubeconfig project
-for project_dir in "kubeconfig" ; do
+for project_dir in "kubeconfig digitalocean/domk8s" ; do
   echo "$project_dir"
   if [ -f "${script_dir}/../pulumi/python/infrastructure/${project_dir}/Pulumi.yaml" ]; then
     pulumi_args="--cwd ${script_dir}/../pulumi/python/infrastructure/${project_dir} --emoji --stack ${PULUMI_STACK}"

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -104,7 +104,7 @@ if [ -s "${script_dir}/../config/pulumi/environment" ] && grep --quiet '^PULUMI_
 fi
 
 while true; do
-  read -e -r -p "Type a for AWS, k for kubeconfig? " infra
+  read -e -r -p "Type a for AWS, d for Digital Ocean, k for kubeconfig? " infra
   case $infra in
   [Aa]*)
     echo "Calling AWS startup script"
@@ -118,6 +118,12 @@ while true; do
     exit 0
     break
     ;;
-  *) echo "Please answer a or k." ;;
+  [Dd]*)
+    echo "Calling Digital Ocean startup script"
+    exec ${script_dir}/start_do.sh
+    exit 0
+    break
+    ;;
+  *) echo "Please answer a, d, or k." ;;
   esac
 done

--- a/bin/start_do.sh
+++ b/bin/start_do.sh
@@ -214,7 +214,7 @@ cd "${script_dir}/../pulumi/python/infrastructure/digitalocean/domk8s"
 pulumi $pulumi_args up
 
 # pulumi stack output cluster_name
-cluster_name=$(pulumi stack output cluster_id -s "${PULUMI_STACK}"  -C /home/jschmidt/repos/kic-reference-architectures/bin/../pulumi/python/infrastructure/digitalocean/domk8s)
+cluster_name=$(pulumi stack output cluster_id -s "${PULUMI_STACK}"  -C ${script_dir}/../pulumi/python/infrastructure/digitalocean/domk8s)
 add_kube_config
 
 if command -v kubectl >/dev/null; then

--- a/bin/start_do.sh
+++ b/bin/start_do.sh
@@ -289,9 +289,14 @@ pulumi $pulumi_args up
 
 header "Bank of Sirius"
 cd "${script_dir}/../pulumi/python/kubernetes/applications/sirius"
-
 pulumi $pulumi_args up
-app_url="$(pulumi stack output --json | python3 "${script_dir}"/../pulumi/python/kubernetes/applications/sirius/verify.py)"
+
+# We currently don't run this becuase in most cases we are going to need to create either a DNS entry or a hostfile
+# mapping for our application.
+# TODO: find a more elegant solution to LB IP / hostname combos for testing the app #82
+# Bind this to something for now
+app_url=" "
+#app_url="$(pulumi stack output --json | python3 "${script_dir}"/../pulumi/python/kubernetes/applications/sirius/verify.py)"
 
 header "Finished!"
 echo "Application can now be accessed at: ${app_url}"

--- a/bin/start_do.sh
+++ b/bin/start_do.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+
+set -o errexit  # abort on nonzero exit status
+set -o nounset  # abort on unbound variable
+set -o pipefail # don't hide errors within pipes
+
+# Don't pollute console output with upgrade notifications
+export PULUMI_SKIP_UPDATE_CHECK=true
+# Run Pulumi non-interactively
+export PULUMI_SKIP_CONFIRMATIONS=true
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+if ! command -v pulumi >/dev/null; then
+  if [ -x "${script_dir}/../pulumi/python/venv/bin/pulumi" ]; then
+    echo "Adding to [${script_dir}/../pulumi/python/venv/bin] to PATH"
+    export PATH="${script_dir}/../pulumi/python/venv/bin:$PATH"
+
+    if ! command -v pulumi >/dev/null; then
+      echo >&2 "Pulumi must be installed to continue"
+      exit 1
+    fi
+  else
+    echo >&2 "Pulumi must be installed to continue"
+    exit 1
+  fi
+fi
+
+if ! command -v python3 >/dev/null; then
+  echo >&2 "Python 3 must be installed to continue"
+  exit 1
+fi
+
+if ! command -v node >/dev/null; then
+  if [ -x "${script_dir}/../pulumi/python/venv/bin/pulumi" ]; then
+    echo "Adding to [${script_dir}/../pulumi/python/venv/bin] to PATH"
+    export PATH="${script_dir}/../pulumi/python/venv/bin:$PATH"
+
+    if ! command -v node >/dev/null; then
+      echo >&2 "NodeJS must be installed to continue"
+      exit 1
+    fi
+  else
+    echo >&2 "NodeJS must be installed to continue"
+    exit 1
+  fi
+fi
+
+if ! command -v git >/dev/null; then
+  echo >&2 "git must be installed to continue"
+  exit 1
+fi
+
+if ! command -v make >/dev/null; then
+  echo >&2 "make is not installed - it must be installed if you intend to build NGINX Kubernetes Ingress Controller from source."
+fi
+
+if ! command -v docker >/dev/null; then
+  echo >&2 "docker is not installed - it must be installed if you intend to build NGINX Kubernetes Ingress Controller from source."
+fi
+
+# Check to see if the user is logged into Pulumi
+if ! pulumi whoami --non-interactive >/dev/null 2>&1; then
+  pulumi login
+
+  if ! pulumi whoami --non-interactive >/dev/null 2>&1; then
+    echo >&2 "Unable to login to Pulumi - exiting"
+    exit 2
+  fi
+fi
+
+if [ ! -f "${script_dir}/../config/pulumi/environment" ]; then
+  touch "${script_dir}/../config/pulumi/environment"
+fi
+
+if ! grep --quiet '^PULUMI_STACK=.*' "${script_dir}/../config/pulumi/environment"; then
+  read -r -e -p "Enter the name of the Pulumi stack to use in all projects: " PULUMI_STACK
+  echo "PULUMI_STACK=${PULUMI_STACK}" >>"${script_dir}/../config/pulumi/environment"
+fi
+
+# Do we have the submodule source....
+#
+# Note: We had been checking for .git, but this is not guaranteed to be
+# there if we build the docker image or use a tarball. So now we look
+# for the src subdirectory which should always be there.
+#
+if [[ -d "${script_dir}/../pulumi/python/kubernetes/applications/sirius/src/src" ]]; then
+  echo "Submodule source found"
+else
+  # Error out with instructions.
+  echo "Bank of Sirius submodule not found"
+  echo " "
+  echo "Please run:"
+  echo "    git submodule update --init --recursive --remote"
+  echo "Inside your git directory and re-run this script"
+  echo ""
+  echo >&2 "Unable to find submodule - exiting"
+  exit 3
+fi
+
+source "${script_dir}/../config/pulumi/environment"
+echo "Configuring all Pulumi projects to use the stack: ${PULUMI_STACK}"
+
+# Create the stack if it does not already exist
+# We skip over the tools directory, because that uses a unique stack for setup of the
+# kubernetes components for installations without them.
+find "${script_dir}/../pulumi/python" -mindepth 1 -maxdepth 7 -type f -name Pulumi.yaml -not -path "*/tools/*" -execdir pulumi stack select --create "${PULUMI_STACK}" \;
+
+if [[ -z "${DIGITALOCEAN_TOKEN+x}" ]]; then
+  echo "DIGITALOCEAN_TOKEN not set"
+  if ! grep --quiet '^DIGITALOCEAN_TOKEN=.*' "${script_dir}/../config/pulumi/environment"; then
+    read -r -e -p "Enter the Digital Ocean Token to use in all projects (leave blank for default): " DIGITALOCEAN_TOKEN
+    if [[ -z "${DIGITALOCEAN_TOKEN}" ]]; then
+      echo "No Digital Ocean token found - exiting"
+      exit 4
+    fi
+    echo "DIGITALOCEAN_TOKEN=${DIGITALOCEAN_TOKEN}" >>"${script_dir}/../config/pulumi/environment"
+    source "${script_dir}/../config/pulumi/environment"
+    find "${script_dir}/../pulumi/python" -mindepth 1 -maxdepth 7 -type f -name Pulumi.yaml -not -path "*/tools/*" -execdir pulumi config set --plaintext digitalocean:token "${DIGITALOCEAN_TOKEN}" \;
+  fi
+else
+  echo "Using DIGITALOCEAN_TOKEN from environment: ${DIGITALOCEAN_TOKEN}"
+  find "${script_dir}/../pulumi/python" -mindepth 1 -maxdepth 7 -type f -name Pulumi.yaml -not -path "*/tools/*" -execdir pulumi config set --plaintext digitalocean:token "${DIGITALOCEAN_TOKEN}" \;
+fi
+
+# The bank of sirius configuration file is stored in the ./sirius/config
+# directory. This is because we cannot pull secrets from different project
+# directories.
+#
+# This work-around is expected to be obsoleted by the work described in
+# https://github.com/pulumi/pulumi/issues/4604, specifically around issue
+# https://github.com/pulumi/pulumi/issues/2307
+#
+# Check for secrets being set
+#
+echo "Checking for required secrets"
+
+# Sirius Accounts Database
+if pulumi config get sirius:accounts_pwd -C ${script_dir}/../pulumi/python/kubernetes/applications/sirius >/dev/null 2>&1; then
+  echo "Password found for the sirius accounts database"
+else
+  echo "Create a password for the sirius accounts database"
+  pulumi config set --secret sirius:accounts_pwd -C ${script_dir}/../pulumi/python/kubernetes/applications/sirius
+fi
+
+# Sirius Ledger Database
+if pulumi config get sirius:ledger_pwd -C ${script_dir}/../pulumi/python/kubernetes/applications/sirius >/dev/null 2>&1; then
+  echo "Password found for sirius ledger database"
+else
+  echo "Create a password for the sirius ledger database"
+  pulumi config set --secret sirius:ledger_pwd -C ${script_dir}/../pulumi/python/kubernetes/applications/sirius
+fi
+
+# Admin password for grafana (see note in __main__.py in prometheus project as to why not encrypted)
+# This is for the deployment that is setup as part of the the prometheus operator driven prometheus-kube-stack.
+#
+if pulumi config get prometheus:adminpass -C ${script_dir}/../pulumi/python/config >/dev/null 2>&1; then
+  echo "Password found for grafana admin account"
+else
+  echo "Create a password for the grafana admin user"
+  pulumi config set prometheus:adminpass -C ${script_dir}/../pulumi/python/config
+fi
+
+# Show colorful fun headers if the right utils are installed
+function header() {
+  "${script_dir}"/../pulumi/python/venv/bin/fart --no_copy -f standard "$1" | "${script_dir}"/../pulumi/python/venv/bin/lolcat
+}
+
+function add_kube_config() {
+  echo "adding ${cluster_name} cluster to local kubeconfig"
+  doctl kubernetes cluster config save ${cluster_name}
+}
+
+function validate_do_credentials() {
+  pulumi_do_token="$(pulumi --cwd "${script_dir}/../pulumi/python/config" config get digitalocean:token)"
+  echo "Validating Digital Ocean credentials"
+  if ! doctl account get >/dev/null; then
+    echo >&2 "Digital Ocean credentials have expired or are not valid"
+    exit 2
+  fi
+}
+
+function retry() {
+  local -r -i max_attempts="$1"
+  shift
+  local -i attempt_num=1
+  until "$@"; do
+    if ((attempt_num == max_attempts)); then
+      echo "Attempt ${attempt_num} failed and there are no more attempts left!"
+      return 1
+    else
+      echo "Attempt ${attempt_num} failed! Trying again in $attempt_num seconds..."
+      sleep $((attempt_num++))
+    fi
+  done
+}
+
+if command -v doctl >/dev/null; then
+  validate_do_credentials
+fi
+
+pulumi_args="--emoji --stack ${PULUMI_STACK}"
+
+# We automatically set this to DO for infra type; since this is a script specific to DO
+# TODO: combined file should query and manage this
+pulumi config set kubernetes:infra_type -C ${script_dir}/../pulumi/python/config DO
+# Bit of a gotcha; we need to know what infra type we have when deploying our application (BoS) due to the
+# way we determine the load balancer FQDN or IP. We can't read the normal config since Sirius uses it's own
+# configuration because of the encryption needed for the passwords.
+pulumi config set kubernetes:infra_type -C ${script_dir}/../pulumi/python/kubernetes/applications/sirius DO
+
+header "DO Kubernetes"
+cd "${script_dir}/../pulumi/python/infrastructure/digitalocean/domk8s"
+pulumi $pulumi_args up
+
+# pulumi stack output cluster_name
+cluster_name=$(pulumi stack output cluster_id -s "${PULUMI_STACK}"  -C /home/jschmidt/repos/kic-reference-architectures/bin/../pulumi/python/infrastructure/digitalocean/domk8s)
+add_kube_config
+
+if command -v kubectl >/dev/null; then
+  echo "Attempting to connect to newly create kubernetes cluster"
+  retry 30 kubectl version >/dev/null
+fi
+
+#
+# This is used to streamline the pieces that follow. Moving forward we can add new logic behind this and this
+# should abstract away for us. This way we just call the kubeconfig project to get the needed information and
+# let the infrastructure specific parts do their own thing (as long as they work with this module)
+#
+header "Kubeconfig"
+cd "${script_dir}/../pulumi/python/infrastructure/kubeconfig"
+pulumi $pulumi_args up
+
+header "Deploying IC"
+cd "${script_dir}/../pulumi/python/kubernetes/nginx/ingress-controller-repo-only"
+pulumi $pulumi_args up
+
+header "Logstore"
+cd "${script_dir}/../pulumi/python/kubernetes/logstore"
+pulumi $pulumi_args up
+
+header "Logagent"
+cd "${script_dir}/../pulumi/python/kubernetes/logagent"
+pulumi $pulumi_args up
+
+header "Cert Manager"
+cd "${script_dir}/../pulumi/python/kubernetes/certmgr"
+pulumi $pulumi_args up
+
+header "Prometheus"
+cd "${script_dir}/../pulumi/python/kubernetes/prometheus"
+pulumi $pulumi_args up
+
+header "Observability"
+cd "${script_dir}/../pulumi/python/kubernetes/observability"
+pulumi $pulumi_args up
+
+header "Bank of Sirius"
+cd "${script_dir}/../pulumi/python/kubernetes/applications/sirius"
+
+pulumi $pulumi_args up
+app_url="$(pulumi stack output --json | python3 "${script_dir}"/../pulumi/python/kubernetes/applications/sirius/verify.py)"
+
+header "Finished!"
+echo "Application can now be accessed at: ${app_url}"

--- a/config/pulumi/Pulumi.stackname.yaml.example
+++ b/config/pulumi/Pulumi.stackname.yaml.example
@@ -282,3 +282,17 @@ config:
 
   # NOTE: The parameters for the Bank of Sirius are set in a configuration directory
   #       within that project.
+
+  ############################################################################
+  # Digital Ocean K8
+  ############################################################################
+  # This is the Kubernetes version to install using Digital Ocean K8s. Changing this value may result in bugs in the
+  # behavior of the reference architecture because it is designed around the APIs for 1.19.
+  domk8s:k8s_version: 1.21.9-do.0
+  # Version of Kubernetes to use
+  domk8s:instance_type: s-2vcpu-4gb
+  # This is the default instance type used by Digital Ocean K8s.
+  domk8s:node_count: 3
+  # The desired node count of the Digital Ocean K8s cluster.
+  domk8s:region: sfo3
+  # The region to deploy the cluster

--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -15,3 +15,5 @@ requests~=2.27.1
 setuptools==60.9.3
 wheel==0.37.1
 yamlreader==3.0.4
+pulumi-digitalocean==4.11.1
+

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -167,6 +167,19 @@ and profile values that will then be added to the `./config/Pulumi/Pulumi.<stack
 file for the project, although there are two other configuration files kept for the application standup and the
 kubernetes extras functionality. For more details on those, please see the README.md in those directories.
 
+### Digital Ocean
+
+If you are using Digital Ocean as your infrastructure provider 
+[configuring Pulumi for Digital Ocean](https://www.pulumi.com/registry/packages/digitalocean/) is necessary. The first step
+is to install the [`doctl`](https://docs.digitalocean.com/reference/doctl/how-to/install/) utility to interact with your
+Digital Ocean account. 
+
+Next, you will need to create a 
+[Digital Ocean Personal API Token](https://docs.digitalocean.com/reference/api/create-personal-access-token/)
+for authentication to Digital Ocean. When you run the script [`./bin/start.sh`](../bin/start.sh) and select a
+Digital Ocean deployment, your token will be added to the `./config/Pulumi/Pulumi.<stack>.yaml`. This is the main configuration file for the project, although there are two other configuration files kept for the application standup
+and the kubernetes extras functionality. For more details on those, please see the README.md in those directories.
+
 ### Pulumi
 
 If you already have run the [`./bin/setup_venv.sh`](../bin/setup_venv.sh)
@@ -181,15 +194,15 @@ Pulumi documentation for additional details regarding the command and alternativ
 The easiest way to run the project is to run [`start.sh`](./start.sh)
 after you have completed the installation steps. When doing so, be sure to choose the same
 [Pulumi stack name](https://www.pulumi.com/docs/intro/concepts/stack/)
-for all of your projects. Additionally, this script will prompt you for the AWS region and profile information. This
+for all of your projects. Additionally, this script will prompt you for infrastructure specific configuration values. This
 information will be used to populate the `./config/pulumi/Pulumi.<stack>.yaml` file.
 
 Alternatively, you can enter into each Pulumi project directory and execute each project independently by doing
 `pulumi up`. Take a look at `start.sh` and dependent scripts to get a feel for the flow.
 
-If you want to destroy the entire environment you can run [`destroy.sh`](./destroy.sh). This script calls either an AWS
-or kubeconfig specific script for the actual destruction. Detailed information and warnings are emitted by the script as
-it runs.
+If you want to destroy the entire environment you can run [`destroy.sh`](./destroy.sh). This script calls the correct
+destroy script based on the information stored in the `./config/Pulumi/Pulumi.<stack>.yaml` configuration file. 
+Detailed information and warnings are emitted by the script as it runs.
 
 ### Running the Project in a Docker Container
 

--- a/docs/status-and-issues.md
+++ b/docs/status-and-issues.md
@@ -23,6 +23,7 @@ All of these configurations use Pulumi code within Python as the Infrastructure 
 | K8 Provider     | Tested | Infrastructure Support      | IC Options                      | FQDN/IP         | Notes                                            |
 |-----------------|--------|-----------------------------|---------------------------------|-----------------|--------------------------------------------------|
 | AWS EKS         | Yes    | Full Infrastructure Standup | Build, Pull (uses ECR)          | Provided        |                                                  |
+| Digtial Ocean         | Yes    | Full Infrastructure Standup |NGINX / NGINX Plus (w/ JWT) (1)     | Manual FQDN (2)||
 | Azure AKS       | Yes    | Kubeconfig Only (3)         | NGINX / NGINX Plus (w/ JWT) (1) | Manual FQDN (2) |                                                  |
 | Google GKE      | Yes    | Kubeconfig Only (3)         | NGINX / NGINX Plus (w/ JWT) (1) | Manual FQDN (2) |                                                  |
 | MicroK8s        | Yes    | Kubeconfig Only (3)         | NGINX / NGINX Plus (w/ JWT) (1) | Manual FQDN (2) | Storage, DNS, and Metallb need to be Enabled (4) |

--- a/pulumi/python/README.md
+++ b/pulumi/python/README.md
@@ -57,6 +57,7 @@ consists of the following:
 ├── config
 ├── infrastructure
 │   ├── aws
+│   ├── digitalocean
 │   └── kubeconfig
 ├── kubernetes
 │   ├── applications
@@ -137,6 +138,17 @@ to the cluster.
 
 The [`ecr`](./infrastructure/aws/ecr) project is responsible for installing and 
 configuring ECR for use with the previously created EKS cluster.
+
+### Digital Ocean
+
+The following directories are specific to Digital Ocean.
+
+#### DOMK8S
+
+Contained within the [`domk8s`](./infrastructure/digitalocean/domk8s) directory contains the 
+logic needed to stand up a Digital Ocean Managed Kubernetes cluster. There are a number of 
+configuration options available to customize the build, however the defaults can be used 
+to create a standard sized cluster in the SFO3 region.
 
 ### NGINX Ingress Controller Docker Image Build
 

--- a/pulumi/python/infrastructure/digitalocean/domk8s/Pulumi.yaml
+++ b/pulumi/python/infrastructure/digitalocean/domk8s/Pulumi.yaml
@@ -1,0 +1,7 @@
+name: do-k8s
+runtime:
+  name: python
+  options:
+    virtualenv: ../../../venv
+config: ../../../../../config/pulumi
+description: Creates new Digital Ocean K8 cluster

--- a/pulumi/python/infrastructure/digitalocean/domk8s/__main__.py
+++ b/pulumi/python/infrastructure/digitalocean/domk8s/__main__.py
@@ -1,0 +1,45 @@
+import collections
+import os
+
+import pulumi
+import pulumi_digitalocean as docean
+from kic_util import pulumi_config
+
+# Configuration details for the K8 cluster
+config = pulumi.Config('domk8s')
+instance_size = config.get('instance_size')
+if not instance_size:
+    instance_size = 's-2vcpu-4gb'
+region = config.get('region')
+if not region:
+    region = 'sfo3'
+node_count = config.get('node_count')
+if not node_count:
+    node_count = 3
+kubernetes_version = config.get('kubernetes_version')
+if not kubernetes_version:
+    kubernetes_version = '1.21.10-do.0'
+
+stack_name = pulumi.get_stack()
+project_name = pulumi.get_project()
+pulumi_user = pulumi_config.get_pulumi_user()
+
+# Derive our names for the cluster and the pool
+resource_name = "do-" + stack_name + "-cluster"
+pool_name = "do-" + stack_name + "-pool"
+
+
+# Create a digital ocean cluster
+cluster = docean.KubernetesCluster(resource_name=resource_name,
+                                   region=region,
+                                   version=kubernetes_version,
+                                   node_pool=docean.KubernetesClusterNodePoolArgs(
+                                       name=pool_name,
+                                       size=instance_size,
+                                       node_count=node_count,
+                                   ))
+
+# Export the clusters' kubeconfig
+pulumi.export("cluster_name", resource_name)
+pulumi.export("cluster_id", cluster.id)
+pulumi.export("kubeconfig", pulumi.Output.unsecret(cluster.kube_configs[0].raw_config))

--- a/pulumi/python/kubernetes/applications/sirius/__main__.py
+++ b/pulumi/python/kubernetes/applications/sirius/__main__.py
@@ -111,6 +111,16 @@ elif infra_type == 'kubeconfig':
     config = pulumi.Config('kubernetes')
     lb_ingress_ip = ingress_stack_ref.get_output('lb_ingress_ip')
     sirius_host = lb_ingress_hostname
+elif infra_type == 'DO':
+    # Logic to extract the FQDN of the load balancer for Ingress
+    ingress_project_name = pulumi_repo_ingress_project_name()
+    ingress_stack_ref_id = f"{pulumi_user}/{ingress_project_name}/{stack_name}"
+    ingress_stack_ref = pulumi.StackReference(ingress_stack_ref_id)
+    lb_ingress_hostname = ingress_stack_ref.get_output('lb_ingress_hostname')
+    # Set back to kubernetes
+    config = pulumi.Config('kubernetes')
+    lb_ingress_ip = ingress_stack_ref.get_output('lb_ingress_ip')
+    sirius_host = lb_ingress_hostname
 else:
     print("Should not get here")
     exit(6)

--- a/pulumi/python/kubernetes/applications/sirius/__main__.py
+++ b/pulumi/python/kubernetes/applications/sirius/__main__.py
@@ -121,9 +121,6 @@ elif infra_type == 'DO':
     config = pulumi.Config('kubernetes')
     lb_ingress_ip = ingress_stack_ref.get_output('lb_ingress_ip')
     sirius_host = lb_ingress_hostname
-else:
-    print("Should not get here")
-    exit(6)
 
 
 # Create the namespace for Bank of Sirius
@@ -384,6 +381,11 @@ if infra_type == 'AWS':
     application_url = sirius_host.apply(lambda host: f'https://{host}')
     pulumi.export('application_url', application_url)
 elif infra_type == 'kubeconfig':
+    pulumi.export('hostname', lb_ingress_hostname)
+    pulumi.export('ipaddress', lb_ingress_ip)
+    #pulumi.export('application_url', f'https://{lb_ingress_hostname}')
+    application_url = sirius_host.apply(lambda host: f'https://{host}')
+elif infra_type == 'DO':
     pulumi.export('hostname', lb_ingress_hostname)
     pulumi.export('ipaddress', lb_ingress_ip)
     #pulumi.export('application_url', f'https://{lb_ingress_hostname}')


### PR DESCRIPTION
### Proposed changes
This change adds support for Digital Ocean, including the ability to stand up and tear down a K8 cluster as well as the additional logic required to deploy the monitoring/management resources and the Bank of Sirius application.

This change only works with the ingress-controller being deployed from the repo (NGINX or NGINX Plus). Full support for building the Ingress Controller, pushing to a private registry, etc will be implemented as part of #81. Full support for the IP/Hostname assigned by the K8 LoadBalancer object will continue to be managed by #82 

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [X] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [X] I have added tests (when possible) that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [X] I have updated necessary documentation
- [X] I have rebased my branch onto master
- [X] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
