### PR TITLE
feat: support NO_COLOR (#99) update jenkins slack calls

### DIFF
--- a/bin/start_aws.sh
+++ b/bin/start_aws.sh
@@ -192,9 +192,14 @@ else
   pulumi config set prometheus:adminpass -C ${script_dir}/../pulumi/python/config
 fi
 
-# Show colorful fun headers if the right utils are installed
+# Show colorful fun headers if the right utils are installed and NO_COLOR is not set
+#
 function header() {
-  "${script_dir}"/../pulumi/python/venv/bin/fart --no_copy -f standard "$1" | "${script_dir}"/../pulumi/python/venv/bin/lolcat
+  if [ -v ${NO_COLOR} ]; then
+    "${script_dir}"/../pulumi/python/venv/bin/fart --no_copy -f standard "$1"
+  else
+    "${script_dir}"/../pulumi/python/venv/bin/fart --no_copy -f standard "$1" | "${script_dir}"/../pulumi/python/venv/bin/lolcat
+  fi
 }
 
 function add_kube_config() {

--- a/bin/start_do.sh
+++ b/bin/start_do.sh
@@ -161,9 +161,14 @@ else
   pulumi config set prometheus:adminpass -C ${script_dir}/../pulumi/python/config
 fi
 
-# Show colorful fun headers if the right utils are installed
+# Show colorful fun headers if the right utils are installed and NO_COLOR is not set
+#
 function header() {
-  "${script_dir}"/../pulumi/python/venv/bin/fart --no_copy -f standard "$1" | "${script_dir}"/../pulumi/python/venv/bin/lolcat
+  if [ -v ${NO_COLOR} ]; then
+    "${script_dir}"/../pulumi/python/venv/bin/fart --no_copy -f standard "$1"
+  else
+    "${script_dir}"/../pulumi/python/venv/bin/fart --no_copy -f standard "$1" | "${script_dir}"/../pulumi/python/venv/bin/lolcat
+  fi
 }
 
 function add_kube_config() {

--- a/bin/start_kube.sh
+++ b/bin/start_kube.sh
@@ -105,9 +105,14 @@ echo "Configuring all Pulumi projects to use the stack: ${PULUMI_STACK}"
 # Do not change the tools directory of add-ons.
 find "${script_dir}/../pulumi" -mindepth 2 -maxdepth 6 -type f -name Pulumi.yaml -not -path "*/tools/*" -execdir pulumi stack select --create "${PULUMI_STACK}" \;
 
-# Show colorful fun headers if the right utils are installed
+# Show colorful fun headers if the right utils are installed and NO_COLOR is not set
+#
 function header() {
-  "${script_dir}"/../pulumi/python/venv/bin/fart --no_copy -f standard "$1" | "${script_dir}"/../pulumi/python/venv/bin/lolcat
+  if [ -v ${NO_COLOR} ]; then
+    "${script_dir}"/../pulumi/python/venv/bin/fart --no_copy -f standard "$1"
+  else
+    "${script_dir}"/../pulumi/python/venv/bin/fart --no_copy -f standard "$1" | "${script_dir}"/../pulumi/python/venv/bin/lolcat
+  fi
 }
 
 function retry() {

--- a/config/pulumi/Pulumi.stackname.yaml.example
+++ b/config/pulumi/Pulumi.stackname.yaml.example
@@ -35,6 +35,7 @@ config:
   #
   # kubernetes:infra_type: AWS
   # kubernetes:infra_type: kubeconfig
+  # kubernetes:infra_type: DO
   #
   # NOTE: For kubernetes installations that are using the kubeconfig file, there are three
   #       other variables that need to be set. This includes the fully qualified path to the

--- a/extras/jenkins/AWS/Jenkinsfile
+++ b/extras/jenkins/AWS/Jenkinsfile
@@ -30,7 +30,7 @@ pipeline {
         AWS_SECRET_ACCESS_KEY  = credentials('AWS_SECRET_ACCESS_KEY')
         AWS_SESSION_TOKEN      = credentials('AWS_SESSION_TOKEN')
         NGINX_JWT              = credentials('NGINX_JWT')
-        NO_COLOR               = TRUE
+        NO_COLOR               = "TRUE"
 
     }
 
@@ -194,7 +194,7 @@ pipeline {
           /*
            * We always notify via slack (configured in Jenkins).
            */
-          slackSend()
+          slackSend channel: '#jerkins', message: 'Success: $JOB_NAME $BUILD_NUMBER'
         }
     failure {
 
@@ -202,6 +202,8 @@ pipeline {
            * On failure we still need to remove the partial build; however, we want to make sure we exit with a zero
            * status so we can move on to the next step. Hence the "or true" logic below.W
            */
+
+        slackSend channel: '#jerkins', message: 'Failure: $JOB_NAME $BUILD_NUMBER'
 
           sh '''
               # Destroy our partial build...

--- a/extras/jenkins/AWS/Jenkinsfile
+++ b/extras/jenkins/AWS/Jenkinsfile
@@ -30,6 +30,7 @@ pipeline {
         AWS_SECRET_ACCESS_KEY  = credentials('AWS_SECRET_ACCESS_KEY')
         AWS_SESSION_TOKEN      = credentials('AWS_SESSION_TOKEN')
         NGINX_JWT              = credentials('NGINX_JWT')
+        NO_COLOR               = TRUE
 
     }
 

--- a/extras/jenkins/AWS/Jenkinsfile
+++ b/extras/jenkins/AWS/Jenkinsfile
@@ -190,20 +190,12 @@ pipeline {
   }
 
   post {
-        always {
-          /*
-           * We always notify via slack (configured in Jenkins).
-           */
-          slackSend channel: '#jerkins', message: 'Success: $JOB_NAME $BUILD_NUMBER'
-        }
     failure {
 
           /*
            * On failure we still need to remove the partial build; however, we want to make sure we exit with a zero
            * status so we can move on to the next step. Hence the "or true" logic below.W
            */
-
-        slackSend channel: '#jerkins', message: 'Failure: $JOB_NAME $BUILD_NUMBER'
 
           sh '''
               # Destroy our partial build...

--- a/extras/jenkins/DigitalOcean/Jenkinsfile
+++ b/extras/jenkins/DigitalOcean/Jenkinsfile
@@ -22,6 +22,7 @@ pipeline {
  environment {
         DIGITALOCEAN_TOKEN     = credentials('DO_TOKEN')
         NGINX_JWT              = credentials('NGINX_JWT')
+        NO_COLOR               = "TRUE"
     }
   stages {
 
@@ -181,7 +182,7 @@ pipeline {
           /*
            * We always notify via slack (configured in Jenkins).
            */
-          slackSend()
+          slackSend channel: '#jerkins', message: 'Success: $JOB_NAME $BUILD_NUMBER'
         }
     failure {
 
@@ -190,6 +191,7 @@ pipeline {
            * status so we can move on to the next step. Hence the "or true" logic below.W
            */
 
+        slackSend channel: '#jerkins', message: 'Failure: $JOB_NAME $BUILD_NUMBER'
           sh '''
               # Destroy our partial build...
               $WORKSPACE/bin/destroy.sh || true

--- a/extras/jenkins/DigitalOcean/Jenkinsfile
+++ b/extras/jenkins/DigitalOcean/Jenkinsfile
@@ -178,12 +178,6 @@ pipeline {
 
   }
   post {
-        always {
-          /*
-           * We always notify via slack (configured in Jenkins).
-           */
-          slackSend channel: '#jerkins', message: 'Success: $JOB_NAME $BUILD_NUMBER'
-        }
     failure {
 
           /*
@@ -191,7 +185,6 @@ pipeline {
            * status so we can move on to the next step. Hence the "or true" logic below.W
            */
 
-        slackSend channel: '#jerkins', message: 'Failure: $JOB_NAME $BUILD_NUMBER'
           sh '''
               # Destroy our partial build...
               $WORKSPACE/bin/destroy.sh || true

--- a/extras/jenkins/K3S/Jenkinsfile
+++ b/extras/jenkins/K3S/Jenkinsfile
@@ -23,8 +23,9 @@ pipeline {
   */
 
  environment {
-        NGINX_JWT              = credentials('NGINX_JWT')
-        POSTRUN_CMD            = credentials('POSTRUN_CMD')
+        NGINX_JWT     = credentials('NGINX_JWT')
+        POSTRUN_CMD   = credentials('POSTRUN_CMD')
+        NO_COLOR      = TRUE
     }
 
   stages {

--- a/extras/jenkins/K3S/Jenkinsfile
+++ b/extras/jenkins/K3S/Jenkinsfile
@@ -214,16 +214,6 @@ pipeline {
 
   }
   post {
-    always {
-
-          /*
-           * We always notify via slack (configured in Jenkins).
-           */
-
-         slackSend channel: '#jerkins', message: 'Success: $JOB_NAME $BUILD_NUMBER'
-
-    }
-
     failure {
 
           /*
@@ -233,7 +223,6 @@ pipeline {
            * We also clean up K3S.
            */
 
-        slackSend channel: '#jerkins', message: 'Failure: $JOB_NAME $BUILD_NUMBER'
         sh '''
             # Destroy our partial build...
             $WORKSPACE/bin/destroy.sh || true

--- a/extras/jenkins/K3S/Jenkinsfile
+++ b/extras/jenkins/K3S/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
  environment {
         NGINX_JWT     = credentials('NGINX_JWT')
         POSTRUN_CMD   = credentials('POSTRUN_CMD')
-        NO_COLOR      = TRUE
+        NO_COLOR      = "TRUE"
     }
 
   stages {
@@ -220,7 +220,8 @@ pipeline {
            * We always notify via slack (configured in Jenkins).
            */
 
-      slackSend()
+         slackSend channel: '#jerkins', message: 'Success: $JOB_NAME $BUILD_NUMBER'
+
     }
 
     failure {
@@ -232,6 +233,7 @@ pipeline {
            * We also clean up K3S.
            */
 
+        slackSend channel: '#jerkins', message: 'Failure: $JOB_NAME $BUILD_NUMBER'
         sh '''
             # Destroy our partial build...
             $WORKSPACE/bin/destroy.sh || true

--- a/extras/jenkins/MicroK8s/Jenkinsfile
+++ b/extras/jenkins/MicroK8s/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
  environment {
         NGINX_JWT     = credentials('NGINX_JWT')
         POSTRUN_CMD   = credentials('POSTRUN_CMD')
-        NO_COLOR      = TRUE
+        NO_COLOR      = "TRUE"
     }
 
   stages {
@@ -225,7 +225,7 @@ pipeline {
            * We always notify via slack (configured in Jenkins).
            */
 
-      slackSend()
+          slackSend channel: '#jerkins', message: 'Success: $JOB_NAME $BUILD_NUMBER'
     }
 
     failure {
@@ -237,6 +237,7 @@ pipeline {
            * We also clean up Microk8s.
            */
 
+        slackSend channel: '#jerkins', message: 'Failure: $JOB_NAME $BUILD_NUMBER'
         sh '''
             # Destroy our partial build...
             $WORKSPACE/bin/destroy.sh || true

--- a/extras/jenkins/MicroK8s/Jenkinsfile
+++ b/extras/jenkins/MicroK8s/Jenkinsfile
@@ -219,15 +219,6 @@ pipeline {
 
   }
   post {
-    always {
-
-          /*
-           * We always notify via slack (configured in Jenkins).
-           */
-
-          slackSend channel: '#jerkins', message: 'Success: $JOB_NAME $BUILD_NUMBER'
-    }
-
     failure {
 
           /*
@@ -237,7 +228,6 @@ pipeline {
            * We also clean up Microk8s.
            */
 
-        slackSend channel: '#jerkins', message: 'Failure: $JOB_NAME $BUILD_NUMBER'
         sh '''
             # Destroy our partial build...
             $WORKSPACE/bin/destroy.sh || true

--- a/extras/jenkins/MicroK8s/Jenkinsfile
+++ b/extras/jenkins/MicroK8s/Jenkinsfile
@@ -23,8 +23,9 @@ pipeline {
   */
 
  environment {
-        NGINX_JWT              = credentials('NGINX_JWT')
-        POSTRUN_CMD            = credentials('POSTRUN_CMD')
+        NGINX_JWT     = credentials('NGINX_JWT')
+        POSTRUN_CMD   = credentials('POSTRUN_CMD')
+        NO_COLOR      = TRUE
     }
 
   stages {


### PR DESCRIPTION
### Proposed changes
This change closes #99 by implementing the NO_COLOR variable for our start scripts which will allow the Jenkins output to be a bit cleaner without ANSI color codes.

This also removes the slackSend() calls from the Jenkinsfiles, as this is redundant when the Slack Global plugin is used. 

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [X] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [X] I have added tests (when possible) that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [X] I have updated necessary documentation
- [X] I have rebased my branch onto master
- [X] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
