### PR TITLE
fix(bug): fix #119 use configuration to enable NGINX Plus

### DIFF
--- a/config/pulumi/Pulumi.stackname.yaml.example
+++ b/config/pulumi/Pulumi.stackname.yaml.example
@@ -91,16 +91,20 @@ config:
   #
 
   # NGINX Kubernetes Ingress Controller (KIC) Configuration
-  kic-helm:chart_name: nginx-ingress
+
   # Chart name for the helm chart for kic
-  kic-helm:chart_version: 0.12.0
+  kic-helm:chart_name: nginx-ingress
   # Chart version for the helm chart for kic
-  kic-helm:helm_repo_name: nginx-stable
+  kic-helm:chart_version: 0.12.0
   # Name of the repo to pull the kic chart from
-  kic-helm:helm_repo_url: https://helm.nginx.com/stable
+  kic-helm:helm_repo_name: nginx-stable
   # URL of the chart repo to pull kic from
-  kic-helm:helm_timeout: 300
+  kic-helm:helm_repo_url: https://helm.nginx.com/stable
   # Timeout value for helm operations in seconds
+  kic-helm:helm_timeout: 300
+  # When set to true, the ingress controller Helm chart will deploy with
+  # NGINX plus support enabled.
+  kic-helm:enable_plus: false
 
   # Acceptable values are default value is (oss_image):
   # source    - build the KIC image from source code

--- a/pulumi/python/kubernetes/nginx/ingress-controller/__main__.py
+++ b/pulumi/python/kubernetes/nginx/ingress-controller/__main__.py
@@ -105,7 +105,8 @@ def build_chart_values(repository: dict) -> helm.ChartOpts:
                 'annotations': {
                     'co.elastic.logs/module': 'nginx'
                 }
-            }
+            },
+            'nginxplus': False
         },
         'prometheus': {
             'create': True,
@@ -133,8 +134,8 @@ def build_chart_values(repository: dict) -> helm.ChartOpts:
                 'tag': image_tag
             })
 
-            values['controller']['nginxplus'] = image_tag.endswith('plus')
-            if values['controller']['nginxplus']:
+            if config.get_bool('enable_plus'):
+                values['controller']['nginxplus'] = True
                 pulumi.log.info("Enabling NGINX Plus")
     else:
         pulumi.log.info(f"Using default ingress controller image as defined in Helm chart")
@@ -207,3 +208,4 @@ ingress_service = srv.status
 pulumi.export('lb_ingress_hostname', pulumi.Output.unsecret(ingress_service.load_balancer.ingress[0].hostname))
 # Print out our status
 pulumi.export("kic_status", pstatus)
+pulumi.export('nginx_plus', pulumi.Output.unsecret(chart_values['controller']['nginxplus']))


### PR DESCRIPTION
We relied on detecting the string 'plus' at the end of the KIC image tag in order to determine if we would be deploying KIC in Plus-enabled mode. This logic was faulty, and it is best to replace it with an explicit configuration option.