### PR TITLE
fix: Allow python setup script to move ahead on `arm4`  architecture

### DIFF
--- a/bin/setup_venv.sh
+++ b/bin/setup_venv.sh
@@ -208,6 +208,7 @@ i386) ARCH="386" ;;
 i686) ARCH="386" ;;
 x86_64) ARCH="amd64" ;;
 aarch64) ARCH="arm64" ;;
+arm64) ARCH="arm64" ;;
 arm) dpkg --print-architecture | grep -q "arm64" && ARCH="arm64" || ARCH="arm" ;;
 *)
   echo >&2 "Unable to determine system architecture."


### PR DESCRIPTION
### Proposed changes
The architecture check performed by `bin/setup_venv.sh` relies on the output
of the `uname -m` command. On M1 macs running macOS 12.0.1 this returns `arm64`.  This change
adds an explicit handler for that response.


### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] I have added tests (when possible) that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
