### PR TITLE
fix: additional updates for Jenkins and updated K8 version for DO

### DIFF
--- a/config/pulumi/Pulumi.stackname.yaml.example
+++ b/config/pulumi/Pulumi.stackname.yaml.example
@@ -293,7 +293,7 @@ config:
   ############################################################################
   # This is the Kubernetes version to install using Digital Ocean K8s. Changing this value may result in bugs in the
   # behavior of the reference architecture because it is designed around the APIs for 1.19.
-  domk8s:k8s_version: 1.21.11-do.0
+  domk8s:k8s_version: 1.22.8-do.0
   # Version of Kubernetes to use
   domk8s:instance_type: s-2vcpu-4gb
   # This is the default instance type used by Digital Ocean K8s.

--- a/config/pulumi/Pulumi.stackname.yaml.example
+++ b/config/pulumi/Pulumi.stackname.yaml.example
@@ -61,8 +61,7 @@ config:
   # AWS: Elastic Kubernetes Service (EKS) Settings
   ############################################################################
 
-  # This is the Kubernetes version to install using EKS. Changing this value may result in bugs in the behavior
-  # of the reference architecture because it is designed around the APIs for 1.19.
+  # This is the Kubernetes version to install using EKS.
   eks:k8s_version: 1.19
   # This is the default instance type used by EKS.
   eks:instance_type: t2.large
@@ -291,8 +290,7 @@ config:
   ############################################################################
   # Digital Ocean Managed Kubernetes
   ############################################################################
-  # This is the Kubernetes version to install using Digital Ocean K8s. Changing this value may result in bugs in the
-  # behavior of the reference architecture because it is designed around the APIs for 1.19.
+  # This is the Kubernetes version to install using Digital Ocean K8s.
   domk8s:k8s_version: 1.22.8-do.0
   # Version of Kubernetes to use
   domk8s:instance_type: s-2vcpu-4gb

--- a/extras/jenkins/AWS/Jenkinsfile
+++ b/extras/jenkins/AWS/Jenkinsfile
@@ -31,6 +31,8 @@ pipeline {
         AWS_SESSION_TOKEN      = credentials('AWS_SESSION_TOKEN')
         NGINX_JWT              = credentials('NGINX_JWT')
         NO_COLOR               = "TRUE"
+        PULUMI_ACCESS_TOKEN    = credentials('PULUMI_ACCESS_TOKEN')
+
 
     }
 

--- a/extras/jenkins/DigitalOcean/Jenkinsfile
+++ b/extras/jenkins/DigitalOcean/Jenkinsfile
@@ -135,6 +135,7 @@ pipeline {
           $WORKSPACE/pulumi/python/venv/bin/pulumi config set prometheus:adminpass "password" -C pulumi/python/config -s marajenkdo${BUILD_NUMBER}
           $WORKSPACE/pulumi/python/venv/bin/pulumi config set prometheus:helm_timeout "600" -C pulumi/python/config -s marajenkdo${BUILD_NUMBER}
           $WORKSPACE/pulumi/python/venv/bin/pulumi config set digitalocean:token "${DO_TOKEN}" --plaintext -C pulumi/python/config -s marajenkdo${BUILD_NUMBER}
+          $WORKSPACE/pulumi/python/venv/bin/pulumi config set domk8s:k8s_version "1.22.8-do.0" -C pulumi/python/config -s marajenkdo${BUILD_NUMBER}
           $WORKSPACE/pulumi/python/venv/bin/pulumi config set sirius:accounts_pwd --secret "Password" -C pulumi/python/kubernetes/applications/sirius -s marajenkdo${BUILD_NUMBER}
           $WORKSPACE/pulumi/python/venv/bin/pulumi config set sirius:ledger_pwd --secret "Password" -C pulumi/python/kubernetes/applications/sirius -s marajenkdo${BUILD_NUMBER}
           '''

--- a/extras/jenkins/DigitalOcean/Jenkinsfile
+++ b/extras/jenkins/DigitalOcean/Jenkinsfile
@@ -22,6 +22,7 @@ pipeline {
  environment {
         DIGITALOCEAN_TOKEN     = credentials('DO_TOKEN')
         NGINX_JWT              = credentials('NGINX_JWT')
+        PULUMI_ACCESS_TOKEN    = credentials('PULUMI_ACCESS_TOKEN')
         NO_COLOR               = "TRUE"
     }
   stages {

--- a/extras/jenkins/DigitalOcean/Jenkinsfile
+++ b/extras/jenkins/DigitalOcean/Jenkinsfile
@@ -66,6 +66,8 @@ pipeline {
             sudo apt -y install figlet openjdk-11-jdk make docker.io
             # Upgrade everything; we always run with latest patches.
             sudo apt -y upgrade
+            # Create the directory for the kubeconfig
+            mkdir -p $HOME/.kube || true
             # Make sure doctl is installed
             sudo snap install doctl
             # Auth to Digital Ocean

--- a/extras/jenkins/DigitalOcean/Jenkinsfile
+++ b/extras/jenkins/DigitalOcean/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
   */
 
  environment {
-        DIGITALOCEAN_TOKEN     = credentials('DO_TOKEN')
+        DIGITALOCEAN_TOKEN     = credentials('DIGITALOCEAN_TOKEN')
         NGINX_JWT              = credentials('NGINX_JWT')
         PULUMI_ACCESS_TOKEN    = credentials('PULUMI_ACCESS_TOKEN')
         NO_COLOR               = "TRUE"
@@ -68,6 +68,7 @@ pipeline {
             sudo apt -y upgrade
             # Create the directory for the kubeconfig
             mkdir -p $HOME/.kube || true
+            chmod 777 $HOME/.kube || true
             # Make sure doctl is installed
             sudo snap install doctl
             # Auth to Digital Ocean
@@ -131,7 +132,7 @@ pipeline {
           $WORKSPACE/pulumi/python/venv/bin/pulumi config set kic-helm:fqdn "marajenks${BUILD_NUMBER}.zathras.io" -C pulumi/python/config -s marajenkdo${BUILD_NUMBER}
           $WORKSPACE/pulumi/python/venv/bin/pulumi config set kic-helm:helm_timeout "600" -C pulumi/python/config -s marajenkdo${BUILD_NUMBER}
           $WORKSPACE/pulumi/python/venv/bin/pulumi config set kubernetes:infra_type "DO" -C pulumi/python/config -s marajenkdo${BUILD_NUMBER}
-          $WORKSPACE/pulumi/python/venv/bin/pulumi config set kubernetes:kubeconfig "/home/jerkins/.kube/config" -C pulumi/python/config -s marajenkdo${BUILD_NUMBER}
+          $WORKSPACE/pulumi/python/venv/bin/pulumi config set kubernetes:kubeconfig "$HOME/.kube/config" -C pulumi/python/config -s marajenkdo${BUILD_NUMBER}
           $WORKSPACE/pulumi/python/venv/bin/pulumi config set logagent:helm_timeout "600" -C pulumi/python/config -s marajenkdo${BUILD_NUMBER}
           $WORKSPACE/pulumi/python/venv/bin/pulumi config set logstore:helm_timeout "600" -C pulumi/python/config -s marajenkdo${BUILD_NUMBER}
           $WORKSPACE/pulumi/python/venv/bin/pulumi config set prometheus:adminpass "password" -C pulumi/python/config -s marajenkdo${BUILD_NUMBER}

--- a/extras/jenkins/K3S/Jenkinsfile
+++ b/extras/jenkins/K3S/Jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
             # Upgrade everything; we always run with latest patches.
             sudo apt -y upgrade
             # Make sure our kubeconfig dir exists…
-            mkdir ~/.kube || true
+            mkdir $HOME/.kube || true
             '''
       }
     }
@@ -126,7 +126,7 @@ pipeline {
          */
 
           sh '''
-            sudo k3s kubectl config view --flatten > ~/.kube/config
+            sudo k3s kubectl config view --flatten > $HOME/.kube/config
             '''
       }
     }
@@ -165,7 +165,7 @@ pipeline {
             $WORKSPACE/pulumi/python/venv/bin/pulumi config set kic-helm:helm_timeout "600" -C pulumi/python/config -s marajenk${BUILD_NUMBER}
             $WORKSPACE/pulumi/python/venv/bin/pulumi config set kubernetes:cluster_name "microk8s-cluster" -C pulumi/python/config -s marajenk${BUILD_NUMBER}
             $WORKSPACE/pulumi/python/venv/bin/pulumi config set kubernetes:infra_type "kubeconfig" -C pulumi/python/config -s marajenk${BUILD_NUMBER}
-            $WORKSPACE/pulumi/python/venv/bin/pulumi config set kubernetes:kubeconfig "~/.kube/config" -C pulumi/python/config -s marajenk${BUILD_NUMBER}
+            $WORKSPACE/pulumi/python/venv/bin/pulumi config set kubernetes:kubeconfig "$HOME/.kube/config" -C pulumi/python/config -s marajenk${BUILD_NUMBER}
             $WORKSPACE/pulumi/python/venv/bin/pulumi config set logagent:helm_timeout "600" -C pulumi/python/config -s marajenk${BUILD_NUMBER}
             $WORKSPACE/pulumi/python/venv/bin/pulumi config set logstore:helm_timeout "600" -C pulumi/python/config -s marajenk${BUILD_NUMBER}
             $WORKSPACE/pulumi/python/venv/bin/pulumi config set prometheus:adminpass "password" -C pulumi/python/config -s marajenk${BUILD_NUMBER}

--- a/extras/jenkins/K3S/Jenkinsfile
+++ b/extras/jenkins/K3S/Jenkinsfile
@@ -23,9 +23,10 @@ pipeline {
   */
 
  environment {
-        NGINX_JWT     = credentials('NGINX_JWT')
-        POSTRUN_CMD   = credentials('POSTRUN_CMD')
-        NO_COLOR      = "TRUE"
+        NGINX_JWT           = credentials('NGINX_JWT')
+        POSTRUN_CMD         = credentials('POSTRUN_CMD')
+        PULUMI_ACCESS_TOKEN = credentials('PULUMI_ACCESS_TOKEN')
+        NO_COLOR            = "TRUE"
     }
 
   stages {

--- a/extras/jenkins/Linode/Jenkinsfile
+++ b/extras/jenkins/Linode/Jenkinsfile
@@ -23,6 +23,7 @@ pipeline {
         LINODE_TOKEN           = credentials('LINODE_TOKEN')
         NGINX_JWT              = credentials('NGINX_JWT')
         NO_COLOR               = "TRUE"
+        PULUMI_ACCESS_TOKEN    = credentials('PULUMI_ACCESS_TOKEN')
     }
   stages {
 

--- a/extras/jenkins/Linode/Jenkinsfile
+++ b/extras/jenkins/Linode/Jenkinsfile
@@ -66,6 +66,8 @@ pipeline {
             sudo apt -y install figlet openjdk-11-jdk make docker.io
             # Upgrade everything; we always run with latest patches.
             sudo apt -y upgrade
+            # Create the directory for the kubeconfig
+            mkdir -p $HOME/.kube || true
             '''
       }
     }

--- a/extras/jenkins/Linode/Jenkinsfile
+++ b/extras/jenkins/Linode/Jenkinsfile
@@ -68,6 +68,7 @@ pipeline {
             sudo apt -y upgrade
             # Create the directory for the kubeconfig
             mkdir -p $HOME/.kube || true
+            chmod 777 $HOME/.kube || true
             '''
       }
     }
@@ -125,7 +126,7 @@ pipeline {
           $WORKSPACE/pulumi/python/venv/bin/pulumi config set kic-helm:fqdn "marajenks${BUILD_NUMBER}.zathras.io" -C pulumi/python/config -s marajenklke${BUILD_NUMBER}
           $WORKSPACE/pulumi/python/venv/bin/pulumi config set kic-helm:helm_timeout "600" -C pulumi/python/config -s marajenklke${BUILD_NUMBER}
           $WORKSPACE/pulumi/python/venv/bin/pulumi config set kubernetes:infra_type "DO" -C pulumi/python/config -s marajenklke${BUILD_NUMBER}
-          $WORKSPACE/pulumi/python/venv/bin/pulumi config set kubernetes:kubeconfig "/home/jerkins/.kube/config" -C pulumi/python/config -s marajenklke${BUILD_NUMBER}
+          $WORKSPACE/pulumi/python/venv/bin/pulumi config set kubernetes:kubeconfig "$HOME/.kube/config" -C pulumi/python/config -s marajenklke${BUILD_NUMBER}
           $WORKSPACE/pulumi/python/venv/bin/pulumi config set logagent:helm_timeout "600" -C pulumi/python/config -s marajenklke${BUILD_NUMBER}
           $WORKSPACE/pulumi/python/venv/bin/pulumi config set logstore:helm_timeout "600" -C pulumi/python/config -s marajenklke${BUILD_NUMBER}
           $WORKSPACE/pulumi/python/venv/bin/pulumi config set prometheus:adminpass "password" -C pulumi/python/config -s marajenklke${BUILD_NUMBER}

--- a/extras/jenkins/MicroK8s/Jenkinsfile
+++ b/extras/jenkins/MicroK8s/Jenkinsfile
@@ -23,9 +23,10 @@ pipeline {
   */
 
  environment {
-        NGINX_JWT     = credentials('NGINX_JWT')
-        POSTRUN_CMD   = credentials('POSTRUN_CMD')
-        NO_COLOR      = "TRUE"
+        NGINX_JWT               = credentials('NGINX_JWT')
+        POSTRUN_CMD             = credentials('POSTRUN_CMD')
+        NO_COLOR                = "TRUE"
+        PULUMI_ACCESS_TOKEN     = credentials('PULUMI_ACCESS_TOKEN')
     }
 
   stages {

--- a/extras/jenkins/MicroK8s/Jenkinsfile
+++ b/extras/jenkins/MicroK8s/Jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
             # Upgrade everything; we always run with latest patches.
             sudo apt -y upgrade
             # Make sure our kubeconfig dir exists…
-            mkdir ~/.kube || true
+            mkdir $HOME/.kube || true
             '''
       }
     }
@@ -128,7 +128,7 @@ pipeline {
          */
 
           sh '''
-            microk8s.config > /home/jerkins/.kube/config
+            microk8s.config > $HOME/.kube/config
             '''
       }
     }
@@ -167,7 +167,7 @@ pipeline {
             $WORKSPACE/pulumi/python/venv/bin/pulumi config set kic-helm:helm_timeout "600" -C pulumi/python/config -s marajenk${BUILD_NUMBER}
             $WORKSPACE/pulumi/python/venv/bin/pulumi config set kubernetes:cluster_name "microk8s-cluster" -C pulumi/python/config -s marajenk${BUILD_NUMBER}
             $WORKSPACE/pulumi/python/venv/bin/pulumi config set kubernetes:infra_type "kubeconfig" -C pulumi/python/config -s marajenk${BUILD_NUMBER}
-            $WORKSPACE/pulumi/python/venv/bin/pulumi config set kubernetes:kubeconfig "~/.kube/config" -C pulumi/python/config -s marajenk${BUILD_NUMBER}
+            $WORKSPACE/pulumi/python/venv/bin/pulumi config set kubernetes:kubeconfig "$HOME/.kube/config" -C pulumi/python/config -s marajenk${BUILD_NUMBER}
             $WORKSPACE/pulumi/python/venv/bin/pulumi config set logagent:helm_timeout "600" -C pulumi/python/config -s marajenk${BUILD_NUMBER}
             $WORKSPACE/pulumi/python/venv/bin/pulumi config set logstore:helm_timeout "600" -C pulumi/python/config -s marajenk${BUILD_NUMBER}
             $WORKSPACE/pulumi/python/venv/bin/pulumi config set prometheus:adminpass "password" -C pulumi/python/config -s marajenk${BUILD_NUMBER}

--- a/pulumi/python/infrastructure/digitalocean/domk8s/__main__.py
+++ b/pulumi/python/infrastructure/digitalocean/domk8s/__main__.py
@@ -15,7 +15,7 @@ if not node_count:
     node_count = 3
 k8s_version = config.get('k8s_version')
 if not k8s_version:
-    k8s_version = '1.21.11-do.0'
+    k8s_version = '1.22.8-do.0'
 
 stack_name = pulumi.get_stack()
 project_name = pulumi.get_project()


### PR DESCRIPTION
### Proposed changes
This PR fixes two additional issues with the Jenkinsfiles that were not allowing them to start on the jenkins managed agents. Additionally, this contains a bump in the K8 version supplied by DigitalOcean. This changes fairly frequently (the DO version slugs) so it may make sense to programmatically pick the latest within a given range in future updates.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [X] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [X] I have added tests (when possible) that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [X] I have updated necessary documentation
- [X] I have rebased my branch onto master
- [X] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
