### PR TITLE
feat: update creds script for permanent creds

### DIFF
--- a/bin/aws_write_creds.sh
+++ b/bin/aws_write_creds.sh
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
-set -x
-set -v
-
 set -o errexit  # abort on nonzero exit status
-set -o nounset  # abort on unbound variable
 set -o pipefail # don't hide errors within pipes
 
 # 
@@ -25,7 +21,7 @@ if [ ${#missing_auth_vars[@]} -ne 0 ]
 then
     echo "Did not find values for:" 
     printf ' %q\n' "${missing_vars[@]}"
-    echo "Will assume they are in credentials file"
+    echo "Will assume they are in credentials file or not needed"
 else
     echo "Creating credentials file"
     # Create the directory....
@@ -33,8 +29,13 @@ else
     CREDS=~/.aws/credentials
     echo "[default]"                                    >  $CREDS
     echo "aws_access_key_id=$AWS_ACCESS_KEY_ID"         >> $CREDS 
-    echo "aws_secret_access_key=$AWS_SECRET_ACCESS_KEY" >> $CREDS 
-    echo "aws_session_token=$AWS_SESSION_TOKEN"         >> $CREDS 
+    echo "aws_secret_access_key=$AWS_SECRET_ACCESS_KEY" >> $CREDS
+    # This is if we have non-temp credentials...
+    if [[ -z "${AWS_SESSION_TOKEN+x}" ]]; then
+      echo "Not using AWS Session Token"
+    else
+      echo "aws_session_token=$AWS_SESSION_TOKEN"         >> $CREDS
+    fi
 
 fi
 


### PR DESCRIPTION
### Proposed changes
Small change to allow for permanent AWS credentials (which do not contain a session token variable). This logic will account for both temporary and permanent creds. To use permanent credentials, one just needs to ensure that they have not set the AWS_SESSION_TOKEN variable in the Jenkins creds configuration.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [X] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [X] I have added tests (when possible) that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [X] I have updated necessary documentation
- [X] I have rebased my branch onto master
- [X] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
