### PR TITLE
fix: pip3 install now does not accept the `--use-feature=in-tree-build`

### DIFF
--- a/bin/setup_venv.sh
+++ b/bin/setup_venv.sh
@@ -197,7 +197,7 @@ fi
 # Install general package requirements
 pip3 install --requirement "${script_dir}/../pulumi/python/requirements.txt"
 # Install local common utilities module
-pip3 install --use-feature=in-tree-build "${script_dir}/../pulumi/python/utility/kic-pulumi-utils" &&
+pip3 install "${script_dir}/../pulumi/python/utility/kic-pulumi-utils" &&
   rm -rf "${script_dir}/../pulumi/python/utility/kic-pulumi-utils/.eggs" \
     "${script_dir}/../pulumi/python/utility/kic-pulumi-utils/build" \
     "${script_dir}/../pulumi/python/utility/kic-pulumi-utils/kic_pulumi_utils.egg-info"


### PR DESCRIPTION
The feature flag `--use-feature=in-tree-build` was introduced in pip 21.1 and then
the feature was mainlined in pip 21.3.  With the flag in place `pip install` command
fails and `kic_utils` fails to build.

Based on the changelog which states that this behavior is default in pip 21.3+ and the current
build installs pip 22.1 we remove the flag.

fixes #145

### Proposed changes
Describe the use case and detail of the change. If this PR addresses an issue 
on GitHub, make sure to include a link to that issue here in this description 
(not in the title of the PR).

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have added tests (when possible) that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
