### PR TITLE
fix: pin pulumi eks to working version

### DIFF
--- a/pulumi/python/requirements.txt
+++ b/pulumi/python/requirements.txt
@@ -6,7 +6,7 @@ nodeenv~=1.6.0
 passlib~=1.7.4
 pulumi-aws>=4.37.5
 pulumi-docker==3.1.0
-pulumi-eks>=0.37.1
+pulumi-eks==0.39.0
 pulumi-kubernetes==3.19.1
 pycryptodome~=3.14.0
 PyYAML~=5.4.1


### PR DESCRIPTION
### Proposed changes
Small fix to address error with alphav1/betav1 authentication to AWS EKS; these requirements need to be reviewed in order to make AWS EKS work with the most recent versions of K8 and the components, however it has proven to be very touchy. This makes it work for now.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [X] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [X] I have added tests (when possible) that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [X] I have updated necessary documentation
- [X] I have rebased my branch onto master
- [X] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
