### PR TITLE
fix: pin version of microk8s snap

### DIFF
--- a/extras/jenkins/MicroK8s/Jenkinsfile
+++ b/extras/jenkins/MicroK8s/Jenkinsfile
@@ -112,7 +112,7 @@ pipeline {
 
       steps {
           sh '''
-            snap install microk8s --classic
+            snap install microk8s --classic --channel=1.23/stable
             microk8s.enable storage dns helm3
             microk8s.enable metallb 192.168.100.100/30
             '''


### PR DESCRIPTION
### Proposed changes
This is a work-around for the issue found in #151  - it merely pins the microk8s version to 1.23. We do need to figure out why 1.24 is failing and see if that failure is consistent across all deployments.

This does open up a discussion into the wider issue of versions within MARA.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [X] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [X] I have added tests (when possible) that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [X] I have updated necessary documentation
- [X] I have rebased my branch onto master
- [X] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
