### PR TITLE
bugfix: change pipenv install to pipenv sync to avoid updating deps at build time

### DIFF
--- a/bin/setup_venv.sh
+++ b/bin/setup_venv.sh
@@ -183,7 +183,8 @@ pip3 install pipenv
 # Install certain utility packages like `nodeenv` and `wheel` that aid
 # in the installation of other build tools and dependencies
 # required by the other python packages.
-PIPENV_VERBOSITY=-1 PIPENV_PIPFILE="${script_dir}/../pulumi/python/Pipfile" pipenv install --dev
+# `pipenv sync` uses only the information in the `Pipfile.lock` ensuring repeatable builds
+PIPENV_VERBOSITY=-1 PIPENV_PIPFILE="${script_dir}/../pulumi/python/Pipfile" pipenv sync --dev
 
 # Install node.js into virtual environment so that it can be used by Python
 # modules that make call outs to it.
@@ -194,7 +195,8 @@ else
 fi
 
 # Install general package requirements
-PIPENV_VERBOSITY=-1 PIPENV_PIPFILE="${script_dir}/../pulumi/python/Pipfile" pipenv install
+# `pipenv sync` uses only the information in the `Pipfile.lock` ensuring repeatable builds
+PIPENV_VERBOSITY=-1 PIPENV_PIPFILE="${script_dir}/../pulumi/python/Pipfile" pipenv sync
 
 # Install local common utilities module
 pip3 install "${script_dir}/../pulumi/python/utility/kic-pulumi-utils"


### PR DESCRIPTION

### Proposed changes
`pipenv install` will actually update the `Pipfile.lock` when run if there are newer versions of non-pinned dependences or sub dependencies.  This was causing issues with repeatable installs of python dependencies.

This change changes the `setup_venv.sh` script to use `pipenv sync` which does what you'd expect `install` to do and install strictly from the `Pipenv.lock`.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have added tests (when possible) that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
