### PR TITLE
fix: typo in find command was causing pulumi stacks to not be deleted

### DIFF
--- a/extras/jenkins/AWS/Jenkinsfile
+++ b/extras/jenkins/AWS/Jenkinsfile
@@ -188,7 +188,7 @@ pipeline {
 
           sh '''
             $WORKSPACE/bin/destroy.sh
-            find . -mindepth 2 -maxdepth 6 -type f -name Pulumi.yaml -execdir pulumi stack rm marajenkaws${BUILD_NUMBER} --force --yes \\;
+            find . -mindepth 2 -maxdepth 6 -type f -name Pulumi.yaml -execdir $WORKSPACE/pulumi/python/venv/bin/pulumi stack rm marajenkaws${BUILD_NUMBER} --force --yes \;
             '''
       }
     }

--- a/extras/jenkins/DigitalOcean/Jenkinsfile
+++ b/extras/jenkins/DigitalOcean/Jenkinsfile
@@ -197,7 +197,7 @@ pipeline {
               # Destroy our partial build...
               $WORKSPACE/bin/destroy.sh || true
               # Clean up the Pulumi stack if it exists for our run - which it shouldn\'t, but you never know.
-              find  $WORKSPACE -mindepth 2 -maxdepth 7 -type f -name Pulumi.yaml -execdir $WORKSPACE/pulumi/python/venv/bin/pulumi stack rm marajenk${BUILD_NUMBER}  --force --yes  \\;
+              find  $WORKSPACE -mindepth 2 -maxdepth 7 -type f -name Pulumi.yaml -execdir $WORKSPACE/pulumi/python/venv/bin/pulumi stack rm marajenk${BUILD_NUMBER}  --force --yes  \;
               '''
     }
    }

--- a/extras/jenkins/K3S/Jenkinsfile
+++ b/extras/jenkins/K3S/Jenkinsfile
@@ -228,7 +228,7 @@ pipeline {
             /usr/local/bin/k3s-killall.sh || true
             /usr/local/bin/k3s-uninstall.sh || true
             # Clean up the Pulumi stack if it exists for our run - which it shouldn\'t, but you never know.
-            find  $WORKSPACE -mindepth 2 -maxdepth 7 -type f -name Pulumi.yaml -execdir $WORKSPACE/pulumi/python/venv/bin/pulumi stack rm marajenk${BUILD_NUMBER}  --force --yes  \\;
+            find  $WORKSPACE -mindepth 2 -maxdepth 7 -type f -name Pulumi.yaml -execdir $WORKSPACE/pulumi/python/venv/bin/pulumi stack rm marajenk${BUILD_NUMBER}  --force --yes  \;
             '''
     }
   }

--- a/extras/jenkins/Linode/Jenkinsfile
+++ b/extras/jenkins/Linode/Jenkinsfile
@@ -183,7 +183,7 @@ pipeline {
               # Destroy our partial build...
               $WORKSPACE/bin/destroy.sh || true
               # Clean up the Pulumi stack if it exists for our run - which it shouldn\'t, but you never know.
-              find  $WORKSPACE -mindepth 2 -maxdepth 7 -type f -name Pulumi.yaml -execdir $WORKSPACE/pulumi/python/venv/bin/pulumi stack rm marajenk${BUILD_NUMBER}  --force --yes  \\;
+              find  $WORKSPACE -mindepth 2 -maxdepth 7 -type f -name Pulumi.yaml -execdir $WORKSPACE/pulumi/python/venv/bin/pulumi stack rm marajenk${BUILD_NUMBER}  --force --yes  \;
               '''
     }
    }

--- a/extras/jenkins/MicroK8s/Jenkinsfile
+++ b/extras/jenkins/MicroK8s/Jenkinsfile
@@ -240,7 +240,7 @@ pipeline {
             # True if it’s not there…
             snap remove microk8s || true
             # Clean up the Pulumi stack if it exists for our run - which it shouldn\'t, but you never know.
-            find  $WORKSPACE -mindepth 2 -maxdepth 7 -type f -name Pulumi.yaml -execdir $WORKSPACE/pulumi/python/venv/bin/pulumi stack rm marajenk${BUILD_NUMBER}  --force --yes  \\;
+            find  $WORKSPACE -mindepth 2 -maxdepth 7 -type f -name Pulumi.yaml -execdir $WORKSPACE/pulumi/python/venv/bin/pulumi stack rm marajenk${BUILD_NUMBER}  --force --yes  \;
             '''
     }
   }

--- a/extras/jenkins/Minikube/Jenkinsfile
+++ b/extras/jenkins/Minikube/Jenkinsfile
@@ -249,7 +249,7 @@ _EOF_
             # True if it's not there
             minikube delete || true
             # Clean up the Pulumi stack if it exists for our run - which it shouldn\'t, but you never know.
-            find  $WORKSPACE -mindepth 2 -maxdepth 7 -type f -name Pulumi.yaml -execdir $WORKSPACE/pulumi/python/venv/bin/pulumi stack rm marajenk${BUILD_NUMBER}  --force --yes  \\;
+            find  $WORKSPACE -mindepth 2 -maxdepth 7 -type f -name Pulumi.yaml -execdir $WORKSPACE/pulumi/python/venv/bin/pulumi stack rm marajenk${BUILD_NUMBER}  --force --yes  \;
             '''
     }
   }


### PR DESCRIPTION
### Proposed changes
The mystery of "why the automated jenkins deploys are not cleaning up" has been solved; had an erroneous \ in the find command that caused the execdir command to not be executed. 

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [X] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [X] I have added tests (when possible) that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [X] I have updated necessary documentation
- [X] I have rebased my branch onto master
- [X] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
