### PR TITLE
fix: add wheel back into setup_venv.sh

### DIFF
--- a/bin/setup_venv.sh
+++ b/bin/setup_venv.sh
@@ -196,6 +196,8 @@ pip3 install pipenv
 # Install certain utility packages like `nodeenv` and `wheel` that aid
 # in the installation of other build tools and dependencies
 # required by the other python packages.
+pip3 install wheel
+
 # `pipenv sync` uses only the information in the `Pipfile.lock` ensuring repeatable builds
 PIPENV_VERBOSITY=-1 PIPENV_PIPFILE="${script_dir}/../pulumi/python/Pipfile" pipenv sync --dev
 


### PR DESCRIPTION
### Proposed changes
At some point, the installation of `wheel` as a separate item in the `setup_venv.sh` script was removed. This resulted in an issue on the Apple ARM architecture, as tracked in #186.

This change adds `wheel` back into the setup file, and closes #186.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [X] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [X] I have added tests (when possible) that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [X] I have updated necessary documentation
- [X] I have rebased my branch onto master
- [X] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
