### PR TITLE
fix: adjust where grafana password is stored for kubeconfig deploys

### DIFF
--- a/bin/start_kube.sh
+++ b/bin/start_kube.sh
@@ -266,13 +266,13 @@ fi
 # Admin password for grafana (see note in __main__.py in prometheus project as to why not encrypted)
 # This is for the deployment that is setup as part of the the prometheus operator driven prometheus-kube-stack.
 #
-if pulumi config get prometheus:adminpass -C ${script_dir}/../pulumi/python/config >/dev/null 2>&1; then
+if pulumi config get prometheus:adminpass -C "${script_dir}"/../pulumi/python/kubernetes/secrets >/dev/null 2>&1; then
   echo "Existing password found for grafana admin user"
 else
   echo "Create a password for the grafana admin user; this password will be used to access the Grafana dashboard"
-  echo "This should be an alphanumeric string without any shell special characters; it is presented in plain text"
-  echo "due to current limitations with Pulumi secrets. You will need this password to access the Grafana dashboard."
-  pulumi config set prometheus:adminpass -C ${script_dir}/../pulumi/python/config
+  echo "This should be an alphanumeric string without any shell special characters. You will need this password to"
+  echo "access the Grafana dashboard."
+	pulumi config set prometheus:adminpass --secret -C "${script_dir}"/../pulumi/python/kubernetes/secrets
 fi
 
 #

--- a/pulumi/python/requirements.txt
+++ b/pulumi/python/requirements.txt
@@ -4,10 +4,10 @@ fart~=0.1.5
 lolcat~=1.4
 nodeenv~=1.6.0
 passlib~=1.7.4
-pulumi-aws>=4.39.0
-pulumi-docker==3.1.0
-pulumi-eks>=0.41.2
-pulumi-kubernetes==3.20.1
+pulumi-aws==5.20.0
+pulumi-docker==3.6.0
+pulumi-eks==0.42.7
+pulumi-kubernetes==3.22.1
 pycryptodome~=3.14.0
 PyYAML~=5.4.1
 requests~=2.27.1
@@ -15,7 +15,7 @@ setuptools==62.1.0
 setuptools-git-versioning==1.9.2
 wheel==0.37.1
 yamlreader==3.0.4
-pulumi-digitalocean==4.12.0
-pulumi-linode==3.7.1
-linode-cli~=5.17.2
-pulumi~=3.36.0
+pulumi-digitalocean==4.16.0
+pulumi-linode==3.10.1
+linode-cli==5.26.0
+pulumi~=3.46.1

--- a/pulumi/python/requirements.txt
+++ b/pulumi/python/requirements.txt
@@ -4,10 +4,10 @@ fart~=0.1.5
 lolcat~=1.4
 nodeenv~=1.6.0
 passlib~=1.7.4
-pulumi-aws==5.20.0
-pulumi-docker==3.6.0
-pulumi-eks==0.42.7
-pulumi-kubernetes==3.22.1
+pulumi-aws>=4.39.0
+pulumi-docker==3.1.0
+pulumi-eks>=0.41.2
+pulumi-kubernetes==3.20.1
 pycryptodome~=3.14.0
 PyYAML~=5.4.1
 requests~=2.27.1
@@ -15,7 +15,7 @@ setuptools==62.1.0
 setuptools-git-versioning==1.9.2
 wheel==0.37.1
 yamlreader==3.0.4
-pulumi-digitalocean==4.16.0
-pulumi-linode==3.10.1
-linode-cli==5.26.0
-pulumi~=3.46.1
+pulumi-digitalocean==4.12.0
+pulumi-linode==3.7.1
+linode-cli~=5.17.2
+pulumi~=3.36.0


### PR DESCRIPTION
### Proposed changes
This minor change updates where the kubeconfig deployments store the prometheus/grafana password; it is now 
stored in the secrets project, not the main project configuration.

Closes #204 

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [X] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [X] I have added tests (when possible) that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [X] I have updated necessary documentation
- [ X I have rebased my branch onto master
- [X] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
