### PR TITLE
fix: update digital ocean token configuration variable and insert warning

### DIFF
--- a/config/pulumi/Pulumi.stackname.yaml.example
+++ b/config/pulumi/Pulumi.stackname.yaml.example
@@ -20,6 +20,16 @@
 # namespace "digitalocean". If you do so you will get undefined and bizarre errors
 # back from Pulumi at runtime.
 #
+# Known verboten namespaces:
+# - aws
+# - digitalocean
+# - gcp
+# - linode
+# - azure
+#
+# This list is subject to change and may not be complete; it is recommended that if
+# you experience errors with a provider you check this.
+#
 # One important exception; if you are providing auth credentials for a given
 # provider you will likely be defining them into that providers namespace. So, the
 # Digital Ocean token does go in "digitalocean:token".

--- a/config/pulumi/Pulumi.stackname.yaml.example
+++ b/config/pulumi/Pulumi.stackname.yaml.example
@@ -13,6 +13,20 @@
 # NOTE: Currently, many of the stacks stood up by this process have sanity checks
 #       that will fill in default values if values are not found in this file.
 #
+# IMPORTANT NOTE ON NAMESPACE NAMES!
+#
+# You CANNOT name your namespace with the same name as a Pulumi provider. As an
+# example, you cannot call your AWS namespace "aws" or your Digital Ocean
+# namespace "digitalocean". If you do so you will get undefined and bizarre errors
+# back from Pulumi at runtime.
+#
+# One important exception; if you are providing auth credentials for a given
+# provider you will likely be defining them into that providers namespace. So, the
+# Digital Ocean token does go in "digitalocean:token".
+#
+# So far 3 maintainers have fallen into this trap and spent hours trying to sort it.
+# Hopefully this helps you from falling into the same trap.
+#
 ################################################################################
 
 config:

--- a/extras/jenkins/DigitalOcean/Jenkinsfile
+++ b/extras/jenkins/DigitalOcean/Jenkinsfile
@@ -137,7 +137,7 @@ pipeline {
           $WORKSPACE/pulumi/python/venv/bin/pulumi config set docean:node_count "3" -C pulumi/python/config -s marajenkdo${BUILD_NUMBER}
           $WORKSPACE/pulumi/python/venv/bin/pulumi config set docean:region "sfo3" -C pulumi/python/config -s marajenkdo${BUILD_NUMBER}
           $WORKSPACE/pulumi/python/venv/bin/pulumi config set kic-helm:fqdn "mara${BUILD_NUMBER}.docean.mantawang.com" -C pulumi/python/config -s marajenkdo${BUILD_NUMBER}
-          $WORKSPACE/pulumi/python/venv/bin/pulumi config set docean:token "${DO_TOKEN}" --plaintext -C pulumi/python/config -s marajenkdo${BUILD_NUMBER}
+          $WORKSPACE/pulumi/python/venv/bin/pulumi config set digitalocean:token "${DO_TOKEN}" --plaintext -C pulumi/python/config -s marajenkdo${BUILD_NUMBER}
           $WORKSPACE/pulumi/python/venv/bin/pulumi config set prometheus:adminpass "${MARA_PASSWORD}" --secret -C pulumi/python/kubernetes/secrets -s marajenkdo${BUILD_NUMBER}
           $WORKSPACE/pulumi/python/venv/bin/pulumi config set sirius:accounts_pwd "${MARA_PASSWORD}" --secret -C pulumi/python/kubernetes/secrets -s marajenkdo${BUILD_NUMBER}
           $WORKSPACE/pulumi/python/venv/bin/pulumi config set sirius:demo_login_pwd "password" --secret -C pulumi/python/kubernetes/secrets -s marajenkdo${BUILD_NUMBER}

--- a/pulumi/python/automation/main.py
+++ b/pulumi/python/automation/main.py
@@ -82,7 +82,7 @@ FLAGS:
     -d, --debug        Enable debug output on all of the commands executed
     -b, --banner-type= Banner type to indicate which project is being executed (e.g. {', '.join(BANNER_TYPES)})
     -h, --help         Prints help information
-    -s, --stack        Specifies the Pulumi stack to use
+    -s, --stack=       Specifies the Pulumi stack to use
     -p, --provider=    Specifies the provider used (e.g. {', '.join(PROVIDERS)})
 
 OPERATIONS:

--- a/pulumi/python/automation/providers/do.py
+++ b/pulumi/python/automation/providers/do.py
@@ -119,9 +119,10 @@ class DigitalOceanProvider(Provider):
         config = super().new_stack_config(env_config, defaults)
 
         if 'DIGITALOCEAN_TOKEN' not in env_config:
-            config['docean:token'] = input("Digital Ocean API token (this is stored in plain-text - "
+            config['digitalocean:token'] = input("Digital Ocean API token (this is stored in plain-text - "
                                                  "alternatively this can be specified as the environment variable "
                                                  "DIGITALOCEAN_TOKEN): ")
+
 
         token = DigitalOceanProvider.token(stack_config={'config': config}, env_config=env_config)
         do_cli = DoctlCli(access_token=token)
@@ -223,16 +224,16 @@ class DigitalOceanProvider(Provider):
             return env_config['DIGITALOCEAN_TOKEN']
 
         # We were given a reference to a StackConfigParser object
-        if 'config' in stack_config and 'docean:token' in stack_config['config']:
-            return stack_config['config']['docean:token']
+        if 'config' in stack_config and 'digitalocean:token' in stack_config['config']:
+            return stack_config['config']['digitalocean:token']
 
         # We were given a reference to a Pulumi Stack configuration
-        if 'docean:token' in stack_config:
-            return stack_config['docean:token'].value
+        if 'digitalocean:token' in stack_config:
+            return stack_config['digitalocean:token'].value
 
         # Otherwise
         msg = 'When using the Digital Ocean provider, an API token must be specified - ' \
-              'this token can be specified with the Pulumi config parameter docean:token ' \
+              'this token can be specified with the Pulumi config parameter digitalocean:token ' \
               'or the environment variable DIGITALOCEAN_TOKEN'
         raise InvalidConfigurationException(msg)
 

--- a/pulumi/python/automation/providers/do.py
+++ b/pulumi/python/automation/providers/do.py
@@ -41,6 +41,12 @@ class DoctlCli:
         :return: command to be executed
         """
         return f'{self.base_cmd()} account get'
+    def auth_credentials_cmd(self) -> str:
+        """
+        Runs the doctl auth command for helm usage later in MARA
+        :return: command to be executed
+        """
+        return f'{self.base_cmd()} auth init'
 
     def save_kubernetes_cluster_cmd(self, cluster_name: str) -> str:
         """
@@ -176,7 +182,7 @@ class DigitalOceanProvider(Provider):
         super().validate_stack_config(stack_config=stack_config, env_config=env_config)
         token = DigitalOceanProvider.token(stack_config=stack_config, env_config=env_config)
         do_cli = DoctlCli(access_token=token)
-        _, err = external_process.run(cmd=do_cli.validate_credentials_cmd())
+        _, err = external_process.run(cmd=do_cli.auth_credentials_cmd())
         if err:
             print(f'Digital Ocean authentication error: {err}', file=sys.stderr)
             sys.exit(3)

--- a/pulumi/python/automation/providers/do.py
+++ b/pulumi/python/automation/providers/do.py
@@ -120,7 +120,7 @@ class DigitalOceanProvider(Provider):
 
         if 'DIGITALOCEAN_TOKEN' not in env_config:
             config['digitalocean:token'] = input("Digital Ocean API token (this is stored in plain-text - "
-                                                 "alternatively this can be specified as the environment variable "
+                                                 "you may also need to specify it in the environment variable "
                                                  "DIGITALOCEAN_TOKEN): ")
 
 

--- a/pulumi/python/automation/providers/do.py
+++ b/pulumi/python/automation/providers/do.py
@@ -120,9 +120,8 @@ class DigitalOceanProvider(Provider):
 
         if 'DIGITALOCEAN_TOKEN' not in env_config:
             config['digitalocean:token'] = input("Digital Ocean API token (this is stored in plain-text - "
-                                                 "you may also need to specify it in the environment variable "
+                                                 "YOU WILL ALSO NEED TO SPECIFY IT IN THE ENVIRONMENT VARIABLE "
                                                  "DIGITALOCEAN_TOKEN): ")
-
 
         token = DigitalOceanProvider.token(stack_config={'config': config}, env_config=env_config)
         do_cli = DoctlCli(access_token=token)


### PR DESCRIPTION
### Proposed changes
This is a stop-gap measure to help with #208 - if the user has not specified the DIGITALOCEAN_TOKEN we will
warn them that it also needs to be in the environment.

Additional changes will make this a bit neater, but this will address it in the short term.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [X] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [X] I have added tests (when possible) that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [X] I have updated necessary documentation
- [X] I have rebased my branch onto master
- [X] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
