### PR TITLE
fix: adjust AWS logic to force delete ECR registry that contains images

### DIFF
--- a/extras/jenkins/AWS/Jenkinsfile
+++ b/extras/jenkins/AWS/Jenkinsfile
@@ -188,15 +188,11 @@ pipeline {
          * Clean up the environment; this includes running the destroy script to remove our pulumi resources and
          * destroy the deployed infrastructure in AWS
          *
-         * AWS will not remove a registry that contains images, so we do a force removal here; this should ultimately
-         * be fixed in the code.
-         *
          * After that completes, we remove the pulumi stack from the project with the find command; this is because
          * we need to delete the stack in each project it's been instantiated in.
          */
 
           sh '''
-            $WORKSPACE/pulumi/python/venv/bin/aws ecr delete-repository --repository-name ingress-controller-marajenkaws${BUILD_NUMBER} --force
             $WORKSPACE/pulumi/python/runner -p aws -s marajenkaws${BUILD_NUMBER} destroy
             find . -mindepth 2 -maxdepth 6 -type f -name Pulumi.yaml -execdir $WORKSPACE/pulumi/python/venv/bin/pulumi stack rm marajenkaws${BUILD_NUMBER} --force --yes \\;
              '''

--- a/pulumi/python/infrastructure/aws/ecr/__main__.py
+++ b/pulumi/python/infrastructure/aws/ecr/__main__.py
@@ -8,7 +8,7 @@ project_name = pulumi.get_project()
 ecr_repo = ecr.Repository(name=f'ingress-controller-{stack_name}',
                           resource_name=f'nginx-ingress-repository-{stack_name}',
                           image_tag_mutability="MUTABLE",
-                          force_delete=False,
+                          force_delete=True,
                           tags={"Project": project_name, "Stack": stack_name})
 
 pulumi.export('repository_url', ecr_repo.repository_url)


### PR DESCRIPTION
### Proposed changes
This change closes #203, which was a problem where AWS would not allow a registry that contains images to be deleted. This behavior change occurred after MARA went live (the previous behavior would let you delete the registry no matter what). This fix adds the force option to the deployment and removes the scripted delete from the Jenkinsfile for AWS.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [X] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [X] I have added tests (when possible) that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [X] I have updated necessary documentation
- [X] I have rebased my branch onto master
- [X] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
