### PR TITLE
add a cache key to venv restore plugin for easy busting

### DIFF
--- a/.github/workflows/pulumi-aws-tests.yml
+++ b/.github/workflows/pulumi-aws-tests.yml
@@ -14,6 +14,7 @@ jobs:
       id: pulumi-aws-tests-cache-virtualenv
       with:
         requirement_files: pulumi/python/Pipfile.lock
+        custom_cache_key_element: v2
 
     - uses: syphar/restore-pip-download-cache@v1
       if: steps.pulumi-aws-tests-cache-virtualenv.outputs.cache-hit != 'true'
@@ -34,6 +35,7 @@ jobs:
       id: pulumi-aws-tests-cache-virtualenv
       with:
         requirement_files: pulumi/python/Pipfile.lock
+        custom_cache_key_element: v2
 
     - uses: syphar/restore-pip-download-cache@v1
       if: steps.pulumi-aws-tests-cache-virtualenv.outputs.cache-hit != 'true'


### PR DESCRIPTION
### Proposed changes
Per the docs at for the `restore-virtualenv` plugin [here](https://github.com/syphar/restore-virtualenv#custom_cache_key_element) we can specify an arbitrary cache key that adds to the key that is partially defined by the `Pipfile.lock` hash.

We can use this to easily bust cache when we run into python dependency issues which seems to happen every few weeks.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [ ] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] I have added tests (when possible) that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto master
- [ ] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
