### PR TITLE
chore: pin to KIC helm 0.15.2 / image 2.4.2 due to #225

### DIFF
--- a/config/pulumi/Pulumi.stackname.yaml.example
+++ b/config/pulumi/Pulumi.stackname.yaml.example
@@ -151,7 +151,7 @@ config:
   # Chart name for the helm chart for kic
   kic-helm:chart_name: nginx-ingress
   # Chart version for the helm chart for kic
-  kic-helm:chart_version: 0.15.0
+  kic-helm:chart_version: 0.15.2
   # Name of the repo to pull the kic chart from
   kic-helm:helm_repo_name: nginx-stable
   # URL of the chart repo to pull kic from
@@ -175,12 +175,12 @@ config:
   # https://docs.nginx.com/nginx-ingress-controller/installation/pulling-ingress-controller-image/
   #
   # The following are all valid image names:
-  # kic:image_name: private-registry.nginx.com/nginx-ic/nginx-plus-ingress:2.3.0
-  # kic:image_name: private-registry.nginx.com/nginx-ic/nginx-plus-ingress:2.3.0-ot
-  # kic:image_name: docker.io/nginx/nginx-ingress:2.3.0
-  # kic:image_name: nginx/nginx-ingress:2.3.0
-  # kic:image_name: nginx/nginx-ingress:2.3.0-alpine
-  kic:image_name: nginx/nginx-ingress:2.3.0
+  # kic:image_name: private-registry.nginx.com/nginx-ic/nginx-plus-ingress:2.4.2
+  # kic:image_name: private-registry.nginx.com/nginx-ic/nginx-plus-ingress:2.4.2-ot
+  # kic:image_name: docker.io/nginx/nginx-ingress:2.4.2
+  # kic:image_name: nginx/nginx-ingress:2.4.2
+  # kic:image_name: nginx/nginx-ingress:2.4.2-alpine
+  kic:image_name: nginx/nginx-ingress:2.4.2
 
 
   ############################################################################

--- a/pulumi/python/kubernetes/nginx/ingress-controller-repo-only/__main__.py
+++ b/pulumi/python/kubernetes/nginx/ingress-controller-repo-only/__main__.py
@@ -19,7 +19,7 @@ if not chart_name:
     chart_name = 'nginx-ingress'
 chart_version = config.get('chart_version')
 if not chart_version:
-    chart_version = '0.15.0'
+    chart_version = '0.15.2'
 helm_repo_name = config.get('helm_repo_name')
 if not helm_repo_name:
     helm_repo_name = 'nginx-stable'
@@ -31,7 +31,7 @@ if not nginx_repository:
     nginx_repository = "nginx/nginx-ingress"
 nginx_tag = config.get('nginx_tag')
 if not nginx_tag:
-    nginx_tag = "2.4.0"
+    nginx_tag = "2.4.2"
 nginx_plus_flag = config.get_bool('nginx_plus_flag')
 if not nginx_plus_flag:
     nginx_plus_flag = False

--- a/pulumi/python/kubernetes/nginx/ingress-controller/__main__.py
+++ b/pulumi/python/kubernetes/nginx/ingress-controller/__main__.py
@@ -17,7 +17,7 @@ if not chart_name:
     chart_name = 'nginx-ingress'
 chart_version = config.get('chart_version')
 if not chart_version:
-    chart_version = '0.15.0'
+    chart_version = '0.15.2'
 helm_repo_name = config.get('helm_repo_name')
 if not helm_repo_name:
     helm_repo_name = 'nginx-stable'

--- a/pulumi/python/utility/kic-image-build/__main__.py
+++ b/pulumi/python/utility/kic-image-build/__main__.py
@@ -5,6 +5,8 @@ from ingress_controller_image_builder_args import IngressControllerImageBuilderA
 from ingress_controller_image_puller_args import IngressControllerImagePullerArgs
 from nginx_plus_args import NginxPlusArgs
 
+DEFAULT_KIC = "nginx/nginx-ingress:2.4.2"
+
 stack_name = pulumi.get_stack()
 project_name = pulumi.get_project()
 
@@ -42,7 +44,11 @@ if image_origin == 'source':
     ingress_image = IngressControllerImage(name='nginx-ingress-controller',
                                            kic_image_args=image_args)
 elif image_origin == 'registry':
-    image_args = IngressControllerImagePullerArgs(image_name=config.get('image_name'))
+    if not config.get('image_name'):
+        image_args = IngressControllerImagePullerArgs(image_name=DEFAULT_KIC)
+    else:
+        image_args = IngressControllerImagePullerArgs(image_name=config.get('image_name'))
+
     ingress_image = IngressControllerImage(name='nginx-ingress-controller',
                                            kic_image_args=image_args)
 else:


### PR DESCRIPTION
### Proposed changes
This is a temp fix for #225 - it pins our NGINX Ingress helm chart to 0.15.2 and our NGINX binary to 2.4.2 if no other value exists in the pulumi configuration for that stack. 

This will be reverted once the issues defined in #225 are mitigated. 

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [X] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [X] I have added tests (when possible) that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [X] I have updated necessary documentation
- [X] I have rebased my branch onto master
- [X] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
