### PR TITLE
ci: use GH secret for FOSSA API key

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Run FOSSA scan and upload build data
         uses: fossa-contrib/fossa-action@v1
         with:
-          fossa-api-key: b7271378f70427d0944ce84fc7d32b6a
+          fossa-api-key: ${{ secrets.FOSSA_API_KEY }}


### PR DESCRIPTION
### Proposed changes
We had previously stored the FOSSA API key directly in the CI manifest file. This change removes the key and uses a secret instead.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [X] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [X] I have added tests (when possible) that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [X] I have updated necessary documentation
- [X] I have rebased my branch onto master
- [X] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
